### PR TITLE
[WF-256] Replace grafana-agent with otel-collector

### DIFF
--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -9,16 +9,16 @@ For detailed usage and provider configuration, refer to the [Terraform provider 
 
 This module deploys the following components and their relations:
 
-| Component | Charm | Role |
-|------------|--------|------|
-| `temporal-frontend` | `temporal-k8s` | Handles client requests and routes workflow tasks. |
-| `temporal-history` | `temporal-k8s` | Manages workflow event histories. |
-| `temporal-matching` | `temporal-k8s` | Manages task queues and matching logic. |
-| `temporal-worker` | `temporal-k8s` | Executes workflows and activities. |
-| `temporal-admin` | `temporal-admin-k8s` | Manages Temporal namespaces, schemas, and system configuration. |
-| `temporal-ui` | `temporal-ui-k8s` | Provides the web interface for viewing workflows. |
-| `postgresql-k8s` | `postgresql-k8s` | Backend database for persistence and visibility data. |
-| *(Optional)* `grafana-agent-k8s` | `grafana-agent-k8s` | Observability integration for COS. |
+| Component                     | Charm                         | Role                                                            |
+| ----------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| `temporal-frontend`           | `temporal-k8s`                | Handles client requests and routes workflow tasks.              |
+| `temporal-history`            | `temporal-k8s`                | Manages workflow event histories.                               |
+| `temporal-matching`           | `temporal-k8s`                | Manages task queues and matching logic.                         |
+| `temporal-worker`             | `temporal-k8s`                | Executes workflows and activities.                              |
+| `temporal-admin`              | `temporal-admin-k8s`          | Manages Temporal namespaces, schemas, and system configuration. |
+| `temporal-ui`                 | `temporal-ui-k8s`             | Provides the web interface for viewing workflows.               |
+| `postgresql-k8s`              | `postgresql-k8s`              | Backend database for persistence and visibility data.           |
+| _(Optional)_ `otel-collector` | `opentelemetry-collector-k8s` | Observability integration for COS.                              |
 
 All Temporal services connect to PostgreSQL for both **primary (db)** and **visibility** stores and to **Temporal Admin** for schema management.
 
@@ -30,26 +30,26 @@ All Temporal services connect to PostgreSQL for both **primary (db)** and **visi
 
 The solution module exposes the following configurable inputs:
 
-| Name | Type | Description | Required |
-|------|------|-------------|-----------|
-| `model` | string | Reference to an existing Juju model to deploy Temporal into | true |
-| `postgresql` | object | Configuration for the `postgresql-k8s` charm module | false |
-| `temporal_server` | object | Configuration for the `temporal-k8s` charm module | false |
-| `temporal_ui` | object | Configuration for the `temporal-ui-k8s` charm module | false |
-| `temporal_admin` | object | Configuration for the `temporal-admin-k8s` charm module | false |
-| `cos_configuration` | bool | Enables COS integration by deploying and relating `grafana-agent-k8s` | false |
-| `existing_grafana_agent_name` | string | Name of an existing `grafana-agent-k8s` deployment to reuse (used only if COS is enabled) | false |
+| Name                           | Type   | Description                                                                                         | Required |
+| ------------------------------ | ------ | --------------------------------------------------------------------------------------------------- | -------- |
+| `model_uuid`                   | string | Reference to an existing Juju model to deploy Temporal into                                         | true     |
+| `postgresql`                   | object | Configuration for the `postgresql-k8s` charm module                                                 | false    |
+| `temporal_server`              | object | Configuration for the `temporal-k8s` charm module                                                   | false    |
+| `temporal_ui`                  | object | Configuration for the `temporal-ui-k8s` charm module                                                | false    |
+| `temporal_admin`               | object | Configuration for the `temporal-admin-k8s` charm module                                             | false    |
+| `cos_configuration`            | bool   | Enables COS integration by deploying and relating `opentelemetry-collector-k8s`                     | false    |
+| `existing_otel_collector_name` | string | Name of an existing `opentelemetry-collector-k8s` deployment to reuse (used only if COS is enabled) | false    |
 
 Each of the charm input objects (`postgresql`, `temporal_server`, `temporal_ui`, `temporal_admin`) supports the following fields:
 
-| Field | Type | Description | Default |
-|-------|------|-------------|----------|
-| `app_name` | string | Application name to deploy | Charm-specific |
-| `channel` | string | Charm channel to deploy from | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL |
-| `revision` | number | Charm revision to use. `0` means the latest available. | `0` |
-| `units` | number | Number of application units | `1` |
-| `config` | map(string) | Charm-specific configuration options | `{}` |
-| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"` |
+| Field                | Type                   | Description                                              | Default                                                       |
+| -------------------- | ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                |
+| `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"16/edge"` for PostgreSQL |
+| `revision`           | number                 | Charm revision to use. `0` means the latest available.   | `0`                                                           |
+| `units`              | number                 | Number of application units                              | `1`                                                           |
+| `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                          |
+| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"`                                                         |
 
 ---
 
@@ -57,15 +57,15 @@ Each of the charm input objects (`postgresql`, `temporal_server`, `temporal_ui`,
 
 Upon apply, this module exports the following outputs:
 
-| Name | Description |
-|------|-------------|
-| `applications` | Map containing all charm modules that make up the Charmed Temporal deployment |
-| `frontend_certificates_requirer` | Map with `app_name` and `requires` endpoint for TLS certificates |
-| `server_nginx_route_requirer` | Map with `app_name` and `requires` endpoint for Temporal Server's NGINX route |
-| `ui_nginx_route_requirer` | Map with `app_name` and `requires` endpoint for Temporal UI's NGINX route |
-| `openfga_requirer` | Map with `app_name` and `requires` endpoint for OpenFGA |
-| `s3_integrator_requirer` | Map with `app_name` and `requires` endpoint for the S3 integrator charm |
-| `grafana_agent_k8s` | Map containing the deployed or reused Grafana Agent when COS is enabled |
+| Name                             | Description                                                                       |
+| -------------------------------- | --------------------------------------------------------------------------------- |
+| `applications`                   | Map containing all charm modules that make up the Charmed Temporal deployment     |
+| `frontend_certificates_requirer` | Map with `app_name` and `requires` endpoint for TLS certificates                  |
+| `server_nginx_route_requirer`    | Map with `app_name` and `requires` endpoint for Temporal Server's NGINX route     |
+| `ui_nginx_route_requirer`        | Map with `app_name` and `requires` endpoint for Temporal UI's NGINX route         |
+| `openfga_requirer`               | Map with `app_name` and `requires` endpoint for OpenFGA                           |
+| `s3_integrator_requirer`         | Map with `app_name` and `requires` endpoint for the S3 integrator charm           |
+| `otel_collector_k8s`             | Map containing the deployed or reused OpenTelemetry Collector when COS is enabled |
 
 ---
 
@@ -73,22 +73,22 @@ Upon apply, this module exports the following outputs:
 
 The following relations are automatically established:
 
-| Integration | Purpose |
-|--------------|----------|
-| `temporal-frontend ↔ postgresql` | Main database connection. |
-| `temporal-frontend ↔ postgresql (visibility)` | Visibility database connection. |
-| `temporal-history ↔ postgresql` | History persistence. |
-| `temporal-history ↔ postgresql (visibility)` | History visibility store. |
-| `temporal-matching ↔ postgresql` | Matching persistence. |
-| `temporal-matching ↔ postgresql (visibility)` | Matching visibility store. |
-| `temporal-worker ↔ postgresql` | Worker persistence. |
-| `temporal-worker ↔ postgresql (visibility)` | Worker visibility store. |
-| `temporal-admin ↔ temporal-frontend` | Schema management for frontend. |
-| `temporal-admin ↔ temporal-history` | Schema management for history. |
-| `temporal-admin ↔ temporal-matching` | Schema management for matching. |
-| `temporal-admin ↔ temporal-worker` | Schema management for worker. |
-| `temporal-frontend ↔ temporal-ui` | UI access integration. |
-| *(Optional)* `grafana-agent ↔ temporal-*` | Metrics integration when COS is enabled. |
+| Integration                                   | Purpose                                  |
+| --------------------------------------------- | ---------------------------------------- |
+| `temporal-frontend ↔ postgresql`              | Main database connection.                |
+| `temporal-frontend ↔ postgresql (visibility)` | Visibility database connection.          |
+| `temporal-history ↔ postgresql`               | History persistence.                     |
+| `temporal-history ↔ postgresql (visibility)`  | History visibility store.                |
+| `temporal-matching ↔ postgresql`              | Matching persistence.                    |
+| `temporal-matching ↔ postgresql (visibility)` | Matching visibility store.               |
+| `temporal-worker ↔ postgresql`                | Worker persistence.                      |
+| `temporal-worker ↔ postgresql (visibility)`   | Worker visibility store.                 |
+| `temporal-admin ↔ temporal-frontend`          | Schema management for frontend.          |
+| `temporal-admin ↔ temporal-history`           | Schema management for history.           |
+| `temporal-admin ↔ temporal-matching`          | Schema management for matching.          |
+| `temporal-admin ↔ temporal-worker`            | Schema management for worker.            |
+| `temporal-frontend ↔ temporal-ui`             | UI access integration.                   |
+| _(Optional)_ `otel-collector ↔ temporal-*`    | Metrics integration when COS is enabled. |
 
 ---
 
@@ -116,18 +116,18 @@ With this minimal input, all charms will be deployed with their default configur
 
 #### Enable COS Integration
 
-To enable COS integration (deploy `grafana-agent-k8s` and relate it to Temporal):
+To enable COS integration (deploy `opentelemetry-collector-k8s` and relate it to Temporal):
 
 ```bash
 terraform apply -var cos_configuration=true
 ```
 
-#### Use an Existing Grafana Agent
+#### Use an Existing OpenTelemetry Collector
 
-If an existing Grafana Agent is already deployed in the same model, reuse it instead of deploying a new one:
+If an existing OpenTelemetry Collector is already deployed in the same model, reuse it instead of deploying a new one:
 
 ```bash
-terraform apply -var cos_configuration=true -var existing_grafana_agent_name="grafana-agent"
+terraform apply -var cos_configuration=true -var existing_otel_collector_name="otel-collector"
 ```
 
 ---
@@ -148,7 +148,7 @@ just destroy ./test/terraform_test.tfvars
   This module provides a default of `"1"` to ensure smooth deployment.
 - The Temporal Worker is pre-provisioned for activity execution.
 - Revisions default to `0`, meaning the latest charm revision for the given channel will be used automatically.
-- `existing_grafana_agent_name` is only used when `cos_configuration=true`. If set without COS enabled, it will be ignored.
+- `existing_otel_collector_name` is only used when `cos_configuration=true`. If set without COS enabled, it will be ignored.
 - Ensure outbound connectivity from your cluster to `api.charmhub.io` for charm downloads.
 
 ---
@@ -159,3 +159,4 @@ just destroy ./test/terraform_test.tfvars
 - [Temporal Admin Operator](https://github.com/canonical/temporal-admin-k8s-operator)
 - [Temporal UI Operator](https://github.com/canonical/temporal-ui-k8s-operator)
 - [PostgreSQL K8s Operator](https://github.com/canonical/postgresql-k8s-operator)
+- [OpenTelemetry Collector K8s Operator](https://github.com/canonical/opentelemetry-collector-k8s-operator)

--- a/modules/charmed-temporal/cos_configuration.tf
+++ b/modules/charmed-temporal/cos_configuration.tf
@@ -1,6 +1,6 @@
 locals {
-  cos_enabled            = var.cos_configuration
-  grafana_agent_app_name = "grafana-agent"
+  cos_enabled             = var.cos_configuration
+  otel_collector_app_name = "otel-collector"
   app_names = {
     postgresql     = var.postgresql.app_name
     temporal_front = "temporal-frontend"
@@ -22,13 +22,13 @@ locals {
   }
 }
 
-resource "juju_application" "grafana_agent_k8s" {
-  count      = local.cos_enabled && var.existing_grafana_agent_name == null ? 1 : 0
-  name       = local.grafana_agent_app_name
+resource "juju_application" "otel_collector_k8s" {
+  count      = local.cos_enabled && var.existing_otel_collector_name == null ? 1 : 0
+  name       = local.otel_collector_app_name
   model_uuid = var.model_uuid
   charm {
-    name    = "grafana-agent-k8s"
-    channel = "1/stable"
+    name    = "opentelemetry-collector-k8s"
+    channel = "2/stable"
   }
   trust  = true
   units  = 1
@@ -36,19 +36,19 @@ resource "juju_application" "grafana_agent_k8s" {
 }
 
 locals {
-  grafana_agent_resolved_name = local.cos_enabled ? (
-    var.existing_grafana_agent_name != null
-    ? var.existing_grafana_agent_name
-    : juju_application.grafana_agent_k8s[0].name
+  otel_collector_resolved_name = local.cos_enabled ? (
+    var.existing_otel_collector_name != null
+    ? var.existing_otel_collector_name
+    : juju_application.otel_collector_k8s[0].name
   ) : null
 }
 
 # COS integrations for Temporal frontend, history, and matching
-resource "juju_integration" "grafana_to_temporal_frontend" {
+resource "juju_integration" "otel_to_temporal_frontend" {
   count      = local.cos_enabled ? 1 : 0
   model_uuid = var.model_uuid
   application {
-    name     = local.grafana_agent_resolved_name
+    name     = local.otel_collector_resolved_name
     endpoint = "metrics-endpoint"
   }
   application {
@@ -57,11 +57,11 @@ resource "juju_integration" "grafana_to_temporal_frontend" {
   }
 }
 
-resource "juju_integration" "grafana_to_temporal_history" {
+resource "juju_integration" "otel_to_temporal_history" {
   count      = local.cos_enabled ? 1 : 0
   model_uuid = var.model_uuid
   application {
-    name     = local.grafana_agent_resolved_name
+    name     = local.otel_collector_resolved_name
     endpoint = "metrics-endpoint"
   }
   application {
@@ -70,11 +70,11 @@ resource "juju_integration" "grafana_to_temporal_history" {
   }
 }
 
-resource "juju_integration" "grafana_to_temporal_matching" {
+resource "juju_integration" "otel_to_temporal_matching" {
   count      = local.cos_enabled ? 1 : 0
   model_uuid = var.model_uuid
   application {
-    name     = local.grafana_agent_resolved_name
+    name     = local.otel_collector_resolved_name
     endpoint = "metrics-endpoint"
   }
   application {
@@ -83,11 +83,11 @@ resource "juju_integration" "grafana_to_temporal_matching" {
   }
 }
 
-resource "juju_integration" "grafana_to_temporal_worker" {
+resource "juju_integration" "otel_to_temporal_worker" {
   count      = local.cos_enabled ? 1 : 0
   model_uuid = var.model_uuid
   application {
-    name     = local.grafana_agent_resolved_name
+    name     = local.otel_collector_resolved_name
     endpoint = "metrics-endpoint"
   }
   application {

--- a/modules/charmed-temporal/outputs.tf
+++ b/modules/charmed-temporal/outputs.tf
@@ -48,11 +48,11 @@ output "openfga_requirer" {
   }
 }
 
-# Grafana Agent (only if cos_configuration = true)
-output "grafana_agent_k8s" {
-  description = "grafana-agent-k8s application name when COS is enabled."
+# OpenTelemetry Collector (only if cos_configuration = true)
+output "otel_collector_k8s" {
+  description = "opentelemetry-collector-k8s application name when COS is enabled."
   value = var.cos_configuration ? {
-    app_name = local.grafana_agent_resolved_name
+    app_name = local.otel_collector_resolved_name
   } : {}
 }
 

--- a/modules/charmed-temporal/variables.tf
+++ b/modules/charmed-temporal/variables.tf
@@ -58,8 +58,8 @@ variable "cos_configuration" {
   default     = false
 }
 
-variable "existing_grafana_agent_name" {
-  description = "Name of an existing grafana-agent-k8s deployed in the model to be reused. If cos_configuration is not true, this input is not used."
+variable "existing_otel_collector_name" {
+  description = "Name of an existing opentelemetry-collector-k8s deployed in the model to be reused. If cos_configuration is not true, this input is not used."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
grafana-agent is EOL. This change migrates the COS integration to use opentelemetry-collector-k8s
charm instead.

Changes:
- Swap grafana-agent-k8s charm with opentelemetry-collector-k8s
- Rename variables
- Rename output grafana_agent_k8s to otel_collector_k8s
- Update README documentation

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #14 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
Updated README for some of the formatting and spelling errors I observed. Also updated the charm channel to `16/edge` as per the `variables.tf` for PostgreSQL

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [X] Documentation updated
