### PR TITLE
[WF-247] Replace postgresql-k8s commit hash with rev742 tag and default channel to 14/stable

### DIFF
--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -32,7 +32,7 @@ The solution module exposes the following configurable inputs:
 
 | Name                           | Type   | Description                                                                                         | Required |
 | ------------------------------ | ------ | --------------------------------------------------------------------------------------------------- | -------- |
-| `model_uuid`                   | string | Reference to an existing Juju model to deploy Temporal into                                         | true     |
+| `model_uuid`                   | string | Reference to an existing Juju model to deploy Temporal into                                       | true     |
 | `postgresql`                   | object | Configuration for the `postgresql-k8s` charm module                                                 | false    |
 | `temporal_server`              | object | Configuration for the `temporal-k8s` charm module                                                   | false    |
 | `temporal_ui`                  | object | Configuration for the `temporal-ui-k8s` charm module                                                | false    |
@@ -45,7 +45,7 @@ Each of the charm input objects (`postgresql`, `temporal_server`, `temporal_ui`,
 | Field                | Type                   | Description                                              | Default                                                       |
 | -------------------- | ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
 | `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                |
-| `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"16/edge"` for PostgreSQL |
+| `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL |
 | `revision`           | number                 | Charm revision to use. `0` means the latest available.   | `0`                                                           |
 | `units`              | number                 | Number of application units                              | `1`                                                           |
 | `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                          |

--- a/modules/charmed-temporal/applications.tf
+++ b/modules/charmed-temporal/applications.tf
@@ -4,6 +4,8 @@ module "postgresql" {
   juju_model = var.model_uuid
   app_name   = var.postgresql.app_name
   channel    = var.postgresql.channel
+  # Override base to ubuntu@22.04 as 14/stable only supports 22.04 (rev742 defaults to 24.04).
+  base       = var.postgresql.base
   units      = var.postgresql.units
   config     = var.postgresql.config
 }

--- a/modules/charmed-temporal/applications.tf
+++ b/modules/charmed-temporal/applications.tf
@@ -1,7 +1,6 @@
 module "postgresql" {
-  # tflint-ignore: terraform_module_pinned_source 16/edge.
-  # TODO: update ref to stable hash, currently it points to 1
-  source     = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=c5b1378aea463ef9922bd11d1778bb5ca7ed5114"
+  # rev742 is the latest charm revision for postgresql-k8s 16/edge.
+  source     = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=rev742"
   juju_model = var.model_uuid
   app_name   = var.postgresql.app_name
   channel    = var.postgresql.channel

--- a/modules/charmed-temporal/variables.tf
+++ b/modules/charmed-temporal/variables.tf
@@ -19,8 +19,9 @@ variable "postgresql" {
   description = "Inputs for postgresql-k8s charm module."
   type = object({
     app_name = optional(string, "postgres")
-    # TODO: Update channel to 16/stable when released. Related issue https://github.com/canonical/charmed-temporal-solutions/issues/12
+    # TODO: Update channel and base to 16/stable (ubuntu@24.04) when released. Related issue https://github.com/canonical/charmed-temporal-solutions/issues/12
     channel  = optional(string, "14/stable")
+    base     = optional(string, "ubuntu@22.04")
     revision = optional(number, 0)
     units    = optional(number, 1)
     config   = optional(map(string), {})

--- a/modules/charmed-temporal/variables.tf
+++ b/modules/charmed-temporal/variables.tf
@@ -19,8 +19,8 @@ variable "postgresql" {
   description = "Inputs for postgresql-k8s charm module."
   type = object({
     app_name = optional(string, "postgres")
-    # TODO: Update channel whenever 16/stable is released. Related issue https://github.com/canonical/charmed-temporal-solutions/issues/12
-    channel  = optional(string, "16/edge")
+    # TODO: Update channel to 16/stable when released. Related issue https://github.com/canonical/charmed-temporal-solutions/issues/12
+    channel  = optional(string, "14/stable")
     revision = optional(number, 0)
     units    = optional(number, 1)
     config   = optional(map(string), {})


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Replace postgresql-k8s commit hash with rev742 tag and default channel to 14/stable

- Replace pinned commit hash with rev742 tag for the postgresql-k8s Terraform module source
- Default postgresql channel from 16/edge to 14/stable

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
## Closes #13 

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
The original commit hash was from the 16/edge branch, for Juju provider v1 compatibility. The 14/stable revision (rev495) is incompatible with provider v1 as its Terraform module predates the upstream provider v1 migration. rev742 (16/edge) is used as the source ref for provider v1 compatibility, while the channel is 14/stable by default.

```
-> charmed-temporal-solutions % juju info postgresql-k8s --channel 16/edge          
name: postgresql-k8s
...
channels: |
  16/stable:     –
  16/candidate:  –
  16/beta:       525  2025-03-19  (525)  28MB  amd64  ubuntu@24.04
  16/edge:       742  2026-02-06  (742)  33MB  amd64  ubuntu@24.04
```

Override base to ubuntu@22.04 as the 16/edge source ref defaults to ubuntu@24.04, which is not available for the 14/stable channel

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
