### PR TITLE
[WF-342, WF-343] Serialize integrations and set PostgreSQL testing profile for just test

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -15,4 +15,4 @@ jobs:
     with:
       module-directory: ./modules/charmed-temporal
       just-targets: '["test", "test-cos", "test-cos-existing"]'
-      timeout-minutes: 60
+      timeout-minutes: 90

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -15,4 +15,4 @@ jobs:
     with:
       module-directory: ./modules/charmed-temporal
       just-targets: '["test", "test-cos", "test-cos-existing"]'
-      timeout-minutes: 90
+      timeout-minutes: 120

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.tfstate
 *.tfstate.*
 *.tfvars
+!modules/charmed-temporal/test/terraform_test.tfvars
 .terraform.lock.hcl

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -99,18 +99,20 @@ This solution module can be used standalone or as part of a higher-level Terrafo
 ### Example: Basic Deployment
 
 ```bash
-terraform apply -var-file=terraform_test.tfvars
+terraform apply -var-file=./test/terraform_test.tfvars
 ```
 
-Committed template: [`test/terraform_test.tfvars`](test/terraform_test.tfvars) sets `postgresql.config.profile = "testing"` for CI/local tests. Running `just validate_test_tfvars terraform_test.tfvars` copies that file to the target path and appends `model_uuid` from the `temporal-test` Juju model.
+The committed template [`test/terraform_test.tfvars`](test/terraform_test.tfvars) sets PostgreSQL `profile = "testing"` and `experimental_max_connections = "400"` for extra headroom in CI/local runs. It does **not** commit secrets; `model_uuid` is injected at runtime.
 
-For a manual apply, use the UUID of an existing Juju model:
+**`just validate_test_tfvars`** (used by `just test`) appends `model_uuid` for the `temporal-test` model to the path you pass—it does **not** copy the file. Avoid running it repeatedly without removing duplicate `model_uuid` lines, or use `just destroy` which strips them via `sed`.
+
+For a manual apply, set the UUID of an existing Juju model in tfvars or on the CLI:
 
 ```hcl
 model_uuid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 ```
 
-You can start from `test/terraform_test.tfvars` and add `model_uuid`, or pass vars on the CLI.
+If you recreate the Juju model (new UUID) but keep an old `terraform.tfstate`, Terraform may report **unknown model** on refresh. Remove local state in this directory (`terraform.tfstate` and `terraform.tfstate.backup`) and apply again. **`just test`** does this automatically after `add-model`; manual or scripted applies still need a clean state when the model UUID changes.
 
 ---
 
@@ -136,18 +138,24 @@ terraform apply -var cos_configuration=true -var existing_otel_collector_name="o
 
 ### Cleanup
 
-To remove the deployment and destroy the associated Juju model:
+To run Terraform destroy, remove the `temporal-test` model, and strip the appended `model_uuid` line from the tfvars file:
 
 ```bash
-just destroy terraform_test.tfvars
+just destroy "./test/terraform_test.tfvars"
 ```
+
+Paths are relative to `modules/charmed-temporal`.
+
+### Local / CI test flow
+
+`just test` runs `add-model`, removes local `terraform.tfstate` (so the new model UUID never clashes with a previous run), `validate_test_tfvars`, `apply`, then **`just wait-for-active`** (polls until every application in `temporal-test` is `active`, up to 20 minutes). It registers `just destroy` on exit so the model and tfvars line are cleaned up.
 
 ---
 
 ## Notes
 
-- Each `juju_integration` uses `depends_on` on the **two charm modules** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Integrations are **not** chained to each other; **`just destroy`** runs **`terraform destroy -parallelism=1`** so CI/local teardown does not remove many integrations at once (avoids Juju/provider delete timeouts). Optional COS metrics integrations depend on the relevant Temporal **module** and the OTEL `juju_application` (when deployed by this module).
-- Test/CI PostgreSQL headroom comes from [`test/terraform_test.tfvars`](test/terraform_test.tfvars) (`profile = "testing"`), merged with `model_uuid` by `just validate_test_tfvars`.
+- Each `juju_integration` uses `depends_on` on the **two charm modules** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Optional COS metrics integrations depend on the relevant Temporal **module** and the OpenTelemetry collector application when this module deploys it (`cos_configuration=true` without `existing_otel_collector_name`).
+- Test/CI PostgreSQL settings are in [`test/terraform_test.tfvars`](test/terraform_test.tfvars); `just validate_test_tfvars` appends `model_uuid` for `temporal-test`.
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.
 - The Temporal Worker is pre-provisioned for activity execution.

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -146,7 +146,7 @@ just destroy terraform_test.tfvars
 
 ## Notes
 
-- Each `juju_integration` uses `depends_on` on the **two charm modules** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Optional COS metrics integrations depend on the relevant Temporal **module** and the OTEL `juju_application` (when deployed by this module).
+- Each `juju_integration` uses `depends_on` on the **two charm modules** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Integrations are **not** chained to each other; **`just destroy`** runs **`terraform destroy -parallelism=1`** so CI/local teardown does not remove many integrations at once (avoids Juju/provider delete timeouts). Optional COS metrics integrations depend on the relevant Temporal **module** and the OTEL `juju_application` (when deployed by this module).
 - Test/CI PostgreSQL headroom comes from [`test/terraform_test.tfvars`](test/terraform_test.tfvars) (`profile = "testing"`), merged with `model_uuid` by `just validate_test_tfvars`.
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -91,6 +91,8 @@ The following relations are automatically established:
 | `temporal-admin ↔ temporal-matching`         | Schema management for matching.             |
 | `temporal-admin ↔ temporal-worker`           | Schema management for worker.               |
 | `temporal-frontend ↔ temporal-ui`            | UI access integration.                      |
+| `temporal-frontend ↔ temporal-ui` (temporal-host-info) | Frontend gRPC host and port for temporal-ui-k8s|
+| `temporal-frontend ↔ temporal-admin` (temporal-host-info) | Frontend gRPC host and port for temporal-admin-k8s|
 | _(Optional)_ `otel-collector ↔ temporal-*`   | Metrics integration when COS is enabled.    |
 
 ---

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -44,14 +44,14 @@ The solution module exposes the following configurable inputs:
 
 Each of the charm input objects (`postgresql`, `pgbouncer`, `temporal_server`, `temporal_ui`, `temporal_admin`) supports the following fields:
 
-| Field                | Type                   | Description                                              | Default                                                                                     |
-| -------------------- | ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                                              |
-| `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL, `"1/stable"` for PgBouncer |
-| `revision`           | number                 | Charm revision to pin. `null` means latest for channel.  | `null`                                                                                      |
-| `units`              | number                 | Number of application units                              | `1`                                                                                         |
-| `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                                                        |
-| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"`                                                                                       |
+| Field                | Type                   | Description                                                | Default                                                                                              |
+| -------------------- | ---------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `app_name`           | string                 | Application name to deploy                                 | Charm-specific                                                                                       |
+| `channel`            | string                 | Charm channel to deploy from                               | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL, `"1/stable"` for PgBouncer          |
+| `revision`           | number                 | Charm revision to pin. `null` unpins (latest for channel). | `0` for `postgresql`, `temporal_server`, `temporal_ui`, and `temporal_admin`; `null` for `pgbouncer` |
+| `units`              | number                 | Number of application units                                | `1`                                                                                                  |
+| `config`             | map(string)            | Charm-specific configuration options                       | `{}`                                                                                                 |
+| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server   | `"1"`                                                                                                |
 
 ---
 
@@ -75,25 +75,25 @@ Upon apply, this module exports the following outputs:
 
 The following relations are automatically established:
 
-| Integration                                  | Purpose                                     |
-| -------------------------------------------- | ------------------------------------------- |
-| `pgbouncer ↔ postgresql`                     | PgBouncer backend connection to PostgreSQL. |
-| `temporal-frontend ↔ pgbouncer`              | Main database connection (via pool).        |
-| `temporal-frontend ↔ pgbouncer (visibility)` | Visibility database connection (via pool).  |
-| `temporal-history ↔ pgbouncer`               | History persistence (via pool).             |
-| `temporal-history ↔ pgbouncer (visibility)`  | History visibility store (via pool).        |
-| `temporal-matching ↔ pgbouncer`              | Matching persistence (via pool).            |
-| `temporal-matching ↔ pgbouncer (visibility)` | Matching visibility store (via pool).       |
-| `temporal-worker ↔ pgbouncer`                | Worker persistence (via pool).              |
-| `temporal-worker ↔ pgbouncer (visibility)`   | Worker visibility store (via pool).         |
-| `temporal-admin ↔ temporal-frontend`         | Schema management for frontend.             |
-| `temporal-admin ↔ temporal-history`          | Schema management for history.              |
-| `temporal-admin ↔ temporal-matching`         | Schema management for matching.             |
-| `temporal-admin ↔ temporal-worker`           | Schema management for worker.               |
-| `temporal-frontend ↔ temporal-ui`            | UI access integration.                      |
-| `temporal-frontend ↔ temporal-ui` (temporal-host-info) | Frontend gRPC host and port for temporal-ui-k8s|
-| `temporal-frontend ↔ temporal-admin` (temporal-host-info) | Frontend gRPC host and port for temporal-admin-k8s|
-| _(Optional)_ `otel-collector ↔ temporal-*`   | Metrics integration when COS is enabled.    |
+| Integration                                               | Purpose                                            |
+| --------------------------------------------------------- | -------------------------------------------------- |
+| `pgbouncer ↔ postgresql`                                  | PgBouncer backend connection to PostgreSQL.        |
+| `temporal-frontend ↔ pgbouncer`                           | Main database connection (via pool).               |
+| `temporal-frontend ↔ pgbouncer (visibility)`              | Visibility database connection (via pool).         |
+| `temporal-history ↔ pgbouncer`                            | History persistence (via pool).                    |
+| `temporal-history ↔ pgbouncer (visibility)`               | History visibility store (via pool).               |
+| `temporal-matching ↔ pgbouncer`                           | Matching persistence (via pool).                   |
+| `temporal-matching ↔ pgbouncer (visibility)`              | Matching visibility store (via pool).              |
+| `temporal-worker ↔ pgbouncer`                             | Worker persistence (via pool).                     |
+| `temporal-worker ↔ pgbouncer (visibility)`                | Worker visibility store (via pool).                |
+| `temporal-admin ↔ temporal-frontend`                      | Schema management for frontend.                    |
+| `temporal-admin ↔ temporal-history`                       | Schema management for history.                     |
+| `temporal-admin ↔ temporal-matching`                      | Schema management for matching.                    |
+| `temporal-admin ↔ temporal-worker`                        | Schema management for worker.                      |
+| `temporal-frontend ↔ temporal-ui`                         | UI access integration.                             |
+| `temporal-frontend ↔ temporal-ui` (temporal-host-info)    | Frontend gRPC host and port for temporal-ui-k8s    |
+| `temporal-frontend ↔ temporal-admin` (temporal-host-info) | Frontend gRPC host and port for temporal-admin-k8s |
+| _(Optional)_ `otel-collector ↔ temporal-*`                | Metrics integration when COS is enabled.           |
 
 ---
 
@@ -173,7 +173,7 @@ Paths are relative to `modules/charmed-temporal`.
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.
 - The Temporal Worker is pre-provisioned for activity execution.
-- Revisions default to `null`, meaning the latest charm revision for the given channel will be used automatically.
+- Charm `revision` optional defaults: `0` for `postgresql`, `temporal_server`, `temporal_ui`, and `temporal_admin`; `null` for `pgbouncer`. For `pgbouncer`, `null` means unpinned (latest for the channel).
 - `existing_otel_collector_name` is only used when `cos_configuration=true`. If set without COS enabled, it will be ignored.
 - Ensure outbound connectivity from your cluster to `api.charmhub.io` for charm downloads.
 

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -151,7 +151,7 @@ just destroy terraform_test.tfvars
 
 ## Notes
 
-- PostgreSQL integrations are applied in sequence (`depends_on` in `integrations.tf`) so many Temporal units do not open database connections at the same time during `terraform apply`. Admin integrations are chained after PostgreSQL wiring; optional COS metrics integrations wait on the core admin relations.
+- Integrations declare `depends_on` for both related charm **modules** (see [issue #18](https://github.com/canonical/charmed-temporal-solutions/issues/18)) and, where useful, prior **`juju_integration`** resources so PostgreSQL relations are not all applied at once (reducing connection spikes during `terraform apply`). Admin integrations are chained after PostgreSQL wiring; optional COS metrics integrations wait on the core admin relations and the OTEL `juju_application` (when present).
 - For automated or local tests where connection pressure is tight, set `postgresql.config.profile = "testing"` on the postgresql-k8s charm (the `just test` recipe writes this into generated `terraform_test.tfvars`).
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -32,7 +32,7 @@ The solution module exposes the following configurable inputs:
 
 | Name                           | Type   | Description                                                                                         | Required |
 | ------------------------------ | ------ | --------------------------------------------------------------------------------------------------- | -------- |
-| `model_uuid`                   | string | Reference to an existing Juju model to deploy Temporal into                                       | true     |
+| `model_uuid`                   | string | Reference to an existing Juju model to deploy Temporal into                                         | true     |
 | `postgresql`                   | object | Configuration for the `postgresql-k8s` charm module                                                 | false    |
 | `temporal_server`              | object | Configuration for the `temporal-k8s` charm module                                                   | false    |
 | `temporal_ui`                  | object | Configuration for the `temporal-ui-k8s` charm module                                                | false    |
@@ -42,14 +42,14 @@ The solution module exposes the following configurable inputs:
 
 Each of the charm input objects (`postgresql`, `temporal_server`, `temporal_ui`, `temporal_admin`) supports the following fields:
 
-| Field                | Type                   | Description                                              | Default                                                       |
-| -------------------- | ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
-| `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                |
+| Field                | Type                   | Description                                              | Default                                                         |
+| -------------------- | ---------------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                  |
 | `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL |
-| `revision`           | number                 | Charm revision to use. `0` means the latest available.   | `0`                                                           |
-| `units`              | number                 | Number of application units                              | `1`                                                           |
-| `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                          |
-| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"`                                                         |
+| `revision`           | number                 | Charm revision to use. `0` means the latest available.   | `0`                                                             |
+| `units`              | number                 | Number of application units                              | `1`                                                             |
+| `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                            |
+| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"`                                                           |
 
 ---
 
@@ -151,7 +151,7 @@ just destroy terraform_test.tfvars
 
 ## Notes
 
-- Integrations declare `depends_on` for both related charm **modules** (see [issue #18](https://github.com/canonical/charmed-temporal-solutions/issues/18)) and, where useful, prior **`juju_integration`** resources so PostgreSQL relations are not all applied at once (reducing connection spikes during `terraform apply`). Admin integrations are chained after PostgreSQL wiring; optional COS metrics integrations wait on the core admin relations and the OTEL `juju_application` (when present).
+- Integrations declare `depends_on` for both related charm **modules** and, where useful, prior **`juju_integration`** resources so PostgreSQL relations are not all applied at once (reducing connection spikes during `terraform apply`). Admin integrations are chained after PostgreSQL wiring; optional COS metrics integrations wait on the core admin relations and the OTEL `juju_application` (when present).
 - For automated or local tests where connection pressure is tight, set `postgresql.config.profile = "testing"` on the postgresql-k8s charm (the `just test` recipe writes this into generated `terraform_test.tfvars`).
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -102,20 +102,15 @@ This solution module can be used standalone or as part of a higher-level Terrafo
 terraform apply -var-file=terraform_test.tfvars
 ```
 
-Sample `terraform_test.tfvars` (use the UUID of an existing Juju model):
+Committed template: [`test/terraform_test.tfvars`](test/terraform_test.tfvars) sets `postgresql.config.profile = "testing"` for CI/local tests. Running `just validate_test_tfvars terraform_test.tfvars` copies that file to the target path and appends `model_uuid` from the `temporal-test` Juju model.
+
+For a manual apply, use the UUID of an existing Juju model:
 
 ```hcl
 model_uuid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-# Optional: extra headroom for PostgreSQL during dense test deploys
-postgresql = {
-  config = {
-    profile = "testing"
-  }
-}
 ```
 
-With `model_uuid` set, all charms will be deployed with their default configuration and automatically related. Running `just validate_test_tfvars terraform_test.tfvars` fills in `model_uuid` and adds `profile = "testing"` for PostgreSQL.
+You can start from `test/terraform_test.tfvars` and add `model_uuid`, or pass vars on the CLI.
 
 ---
 
@@ -151,8 +146,8 @@ just destroy terraform_test.tfvars
 
 ## Notes
 
-- Integrations declare `depends_on` for both related charm **modules** and, where useful, prior **`juju_integration`** resources so PostgreSQL relations are not all applied at once (reducing connection spikes during `terraform apply`). Admin integrations are chained after PostgreSQL wiring; optional COS metrics integrations wait on the core admin relations and the OTEL `juju_application` (when present).
-- For automated or local tests where connection pressure is tight, set `postgresql.config.profile = "testing"` on the postgresql-k8s charm (the `just test` recipe writes this into generated `terraform_test.tfvars`).
+- Each `juju_integration` uses `depends_on` on the **two charm modules** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Optional COS metrics integrations depend on the relevant Temporal **module** and the OTEL `juju_application` (when deployed by this module).
+- Test/CI PostgreSQL headroom comes from [`test/terraform_test.tfvars`](test/terraform_test.tfvars) (`profile = "testing"`), merged with `model_uuid` by `just validate_test_tfvars`.
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.
 - The Temporal Worker is pre-provisioned for activity execution.

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -17,10 +17,11 @@ This module deploys the following components and their relations:
 | `temporal-worker`             | `temporal-k8s`                | Executes workflows and activities.                              |
 | `temporal-admin`              | `temporal-admin-k8s`          | Manages Temporal namespaces, schemas, and system configuration. |
 | `temporal-ui`                 | `temporal-ui-k8s`             | Provides the web interface for viewing workflows.               |
+| `pgbouncer`                   | `pgbouncer-k8s`               | Connection pooler between Temporal services and PostgreSQL.     |
 | `postgresql-k8s`              | `postgresql-k8s`              | Backend database for persistence and visibility data.           |
 | _(Optional)_ `otel-collector` | `opentelemetry-collector-k8s` | Observability integration for COS.                              |
 
-All Temporal services connect to PostgreSQL for both **primary (db)** and **visibility** stores and to **Temporal Admin** for schema management.
+All Temporal services connect to PostgreSQL through **PgBouncer** (session pooling mode by default) for both **primary (db)** and **visibility** stores, and to **Temporal Admin** for schema management.
 
 ---
 
@@ -34,22 +35,23 @@ The solution module exposes the following configurable inputs:
 | ------------------------------ | ------ | --------------------------------------------------------------------------------------------------- | -------- |
 | `model_uuid`                   | string | Reference to an existing Juju model to deploy Temporal into                                         | true     |
 | `postgresql`                   | object | Configuration for the `postgresql-k8s` charm module                                                 | false    |
+| `pgbouncer`                    | object | Configuration for the `pgbouncer-k8s` charm                                                         | false    |
 | `temporal_server`              | object | Configuration for the `temporal-k8s` charm module                                                   | false    |
 | `temporal_ui`                  | object | Configuration for the `temporal-ui-k8s` charm module                                                | false    |
 | `temporal_admin`               | object | Configuration for the `temporal-admin-k8s` charm module                                             | false    |
 | `cos_configuration`            | bool   | Enables COS integration by deploying and relating `opentelemetry-collector-k8s`                     | false    |
 | `existing_otel_collector_name` | string | Name of an existing `opentelemetry-collector-k8s` deployment to reuse (used only if COS is enabled) | false    |
 
-Each of the charm input objects (`postgresql`, `temporal_server`, `temporal_ui`, `temporal_admin`) supports the following fields:
+Each of the charm input objects (`postgresql`, `pgbouncer`, `temporal_server`, `temporal_ui`, `temporal_admin`) supports the following fields:
 
-| Field                | Type                   | Description                                              | Default                                                         |
-| -------------------- | ---------------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
-| `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                  |
-| `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL |
-| `revision`           | number                 | Charm revision to use. `0` means the latest available.   | `0`                                                             |
-| `units`              | number                 | Number of application units                              | `1`                                                             |
-| `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                            |
-| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"`                                                           |
+| Field                | Type                   | Description                                              | Default                                                                                     |
+| -------------------- | ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `app_name`           | string                 | Application name to deploy                               | Charm-specific                                                                              |
+| `channel`            | string                 | Charm channel to deploy from                             | `"1.23/edge"` for Temporal charms, `"14/stable"` for PostgreSQL, `"1/stable"` for PgBouncer |
+| `revision`           | number                 | Charm revision to pin. `null` means latest for channel.  | `null`                                                                                      |
+| `units`              | number                 | Number of application units                              | `1`                                                                                         |
+| `config`             | map(string)            | Charm-specific configuration options                     | `{}`                                                                                        |
+| `num-history-shards` | string (Temporal only) | Defines number of history shards for the Temporal server | `"1"`                                                                                       |
 
 ---
 
@@ -73,22 +75,23 @@ Upon apply, this module exports the following outputs:
 
 The following relations are automatically established:
 
-| Integration                                   | Purpose                                  |
-| --------------------------------------------- | ---------------------------------------- |
-| `temporal-frontend ↔ postgresql`              | Main database connection.                |
-| `temporal-frontend ↔ postgresql (visibility)` | Visibility database connection.          |
-| `temporal-history ↔ postgresql`               | History persistence.                     |
-| `temporal-history ↔ postgresql (visibility)`  | History visibility store.                |
-| `temporal-matching ↔ postgresql`              | Matching persistence.                    |
-| `temporal-matching ↔ postgresql (visibility)` | Matching visibility store.               |
-| `temporal-worker ↔ postgresql`                | Worker persistence.                      |
-| `temporal-worker ↔ postgresql (visibility)`   | Worker visibility store.                 |
-| `temporal-admin ↔ temporal-frontend`          | Schema management for frontend.          |
-| `temporal-admin ↔ temporal-history`           | Schema management for history.           |
-| `temporal-admin ↔ temporal-matching`          | Schema management for matching.          |
-| `temporal-admin ↔ temporal-worker`            | Schema management for worker.            |
-| `temporal-frontend ↔ temporal-ui`             | UI access integration.                   |
-| _(Optional)_ `otel-collector ↔ temporal-*`    | Metrics integration when COS is enabled. |
+| Integration                                  | Purpose                                     |
+| -------------------------------------------- | ------------------------------------------- |
+| `pgbouncer ↔ postgresql`                     | PgBouncer backend connection to PostgreSQL. |
+| `temporal-frontend ↔ pgbouncer`              | Main database connection (via pool).        |
+| `temporal-frontend ↔ pgbouncer (visibility)` | Visibility database connection (via pool).  |
+| `temporal-history ↔ pgbouncer`               | History persistence (via pool).             |
+| `temporal-history ↔ pgbouncer (visibility)`  | History visibility store (via pool).        |
+| `temporal-matching ↔ pgbouncer`              | Matching persistence (via pool).            |
+| `temporal-matching ↔ pgbouncer (visibility)` | Matching visibility store (via pool).       |
+| `temporal-worker ↔ pgbouncer`                | Worker persistence (via pool).              |
+| `temporal-worker ↔ pgbouncer (visibility)`   | Worker visibility store (via pool).         |
+| `temporal-admin ↔ temporal-frontend`         | Schema management for frontend.             |
+| `temporal-admin ↔ temporal-history`          | Schema management for history.              |
+| `temporal-admin ↔ temporal-matching`         | Schema management for matching.             |
+| `temporal-admin ↔ temporal-worker`           | Schema management for worker.               |
+| `temporal-frontend ↔ temporal-ui`            | UI access integration.                      |
+| _(Optional)_ `otel-collector ↔ temporal-*`   | Metrics integration when COS is enabled.    |
 
 ---
 
@@ -98,11 +101,13 @@ This solution module can be used standalone or as part of a higher-level Terrafo
 
 ### Example: Basic Deployment
 
+From the module directory (`modules/charmed-temporal`), with a Juju model already created:
+
 ```bash
 terraform apply -var-file=./test/terraform_test.tfvars
 ```
 
-The committed template [`test/terraform_test.tfvars`](test/terraform_test.tfvars) sets PostgreSQL `profile = "testing"` and `experimental_max_connections = "400"` for extra headroom in CI/local runs. It does **not** commit secrets; `model_uuid` is injected at runtime.
+The committed template [`test/terraform_test.tfvars`](test/terraform_test.tfvars) sets PostgreSQL `profile = "testing"` for lighter resource usage in CI/local runs. It does **not** commit secrets; `model_uuid` is injected at runtime.
 
 **`just validate_test_tfvars`** (used by `just test`) appends `model_uuid` for the `temporal-test` model to the path you pass—it does **not** copy the file. Avoid running it repeatedly without removing duplicate `model_uuid` lines, or use `just destroy` which strips them via `sed`.
 
@@ -154,12 +159,13 @@ Paths are relative to `modules/charmed-temporal`.
 
 ## Notes
 
-- Each `juju_integration` uses `depends_on` on the **two charm modules** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Optional COS metrics integrations depend on the relevant Temporal **module** and the OpenTelemetry collector application when this module deploys it (`cos_configuration=true` without `existing_otel_collector_name`).
+- **PgBouncer:** Temporal services connect to PostgreSQL through `pgbouncer-k8s` (session pooling mode by default). Session pooling is required for Temporal because it uses protocol-level prepared statements, which are incompatible with transaction pooling mode.
+- Each `juju_integration` uses `depends_on` on the **two charm modules/resources** it relates ([#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)). Integrations are **not** chained to each other. Optional COS metrics integrations depend on the relevant Temporal **module** and the OpenTelemetry collector application when this module deploys it (`cos_configuration=true` without `existing_otel_collector_name`).
 - Test/CI PostgreSQL settings are in [`test/terraform_test.tfvars`](test/terraform_test.tfvars); `just validate_test_tfvars` appends `model_uuid` for `temporal-test`.
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.
 - The Temporal Worker is pre-provisioned for activity execution.
-- Revisions default to `0`, meaning the latest charm revision for the given channel will be used automatically.
+- Revisions default to `null`, meaning the latest charm revision for the given channel will be used automatically.
 - `existing_otel_collector_name` is only used when `cos_configuration=true`. If set without COS enabled, it will be ignored.
 - Ensure outbound connectivity from your cluster to `api.charmhub.io` for charm downloads.
 
@@ -171,4 +177,5 @@ Paths are relative to `modules/charmed-temporal`.
 - [Temporal Admin Operator](https://github.com/canonical/temporal-admin-k8s-operator)
 - [Temporal UI Operator](https://github.com/canonical/temporal-ui-k8s-operator)
 - [PostgreSQL K8s Operator](https://github.com/canonical/postgresql-k8s-operator)
+- [PgBouncer K8s Operator](https://github.com/canonical/pgbouncer-k8s-operator)
 - [OpenTelemetry Collector K8s Operator](https://github.com/canonical/opentelemetry-collector-k8s-operator)

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -99,16 +99,23 @@ This solution module can be used standalone or as part of a higher-level Terrafo
 ### Example: Basic Deployment
 
 ```bash
-terraform apply -var-file=test/terraform_test.tfvars
+terraform apply -var-file=terraform_test.tfvars
 ```
 
-Sample `terraform_test.tfvars`:
+Sample `terraform_test.tfvars` (use the UUID of an existing Juju model):
 
 ```hcl
-model = "temporal-test"
+model_uuid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# Optional: extra headroom for PostgreSQL during dense test deploys
+postgresql = {
+  config = {
+    profile = "testing"
+  }
+}
 ```
 
-With this minimal input, all charms will be deployed with their default configuration and automatically related.
+With `model_uuid` set, all charms will be deployed with their default configuration and automatically related. Running `just validate_test_tfvars terraform_test.tfvars` fills in `model_uuid` and adds `profile = "testing"` for PostgreSQL.
 
 ---
 
@@ -137,13 +144,15 @@ terraform apply -var cos_configuration=true -var existing_otel_collector_name="o
 To remove the deployment and destroy the associated Juju model:
 
 ```bash
-just destroy ./test/terraform_test.tfvars
+just destroy terraform_test.tfvars
 ```
 
 ---
 
 ## Notes
 
+- PostgreSQL integrations are applied in sequence (`depends_on` in `integrations.tf`) so many Temporal units do not open database connections at the same time during `terraform apply`. Admin integrations are chained after PostgreSQL wiring; optional COS metrics integrations wait on the core admin relations.
+- For automated or local tests where connection pressure is tight, set `postgresql.config.profile = "testing"` on the postgresql-k8s charm (the `just test` recipe writes this into generated `terraform_test.tfvars`).
 - The Temporal Server charm requires the `num-history-shards` configuration to be set to a positive power of two (e.g., `1`, `2`, `4`).  
   This module provides a default of `"1"` to ensure smooth deployment.
 - The Temporal Worker is pre-provisioned for activity execution.

--- a/modules/charmed-temporal/applications.tf
+++ b/modules/charmed-temporal/applications.tf
@@ -10,6 +10,19 @@ module "postgresql" {
   config = var.postgresql.config
 }
 
+resource "juju_application" "pgbouncer" {
+  name       = var.pgbouncer.app_name
+  model_uuid = var.model_uuid
+  trust      = true
+  units      = var.pgbouncer.units
+  config     = var.pgbouncer.config
+  charm {
+    name     = "pgbouncer-k8s"
+    channel  = var.pgbouncer.channel
+    revision = var.pgbouncer.revision
+  }
+}
+
 module "temporal_frontend" {
   source     = "git::https://github.com/canonical/temporal-k8s-operator//terraform?ref=track/1.23"
   model_uuid = var.model_uuid

--- a/modules/charmed-temporal/applications.tf
+++ b/modules/charmed-temporal/applications.tf
@@ -5,9 +5,9 @@ module "postgresql" {
   app_name   = var.postgresql.app_name
   channel    = var.postgresql.channel
   # Override base to ubuntu@22.04 as 14/stable only supports 22.04 (rev742 defaults to 24.04).
-  base       = var.postgresql.base
-  units      = var.postgresql.units
-  config     = var.postgresql.config
+  base   = var.postgresql.base
+  units  = var.postgresql.units
+  config = var.postgresql.config
 }
 
 module "temporal_frontend" {

--- a/modules/charmed-temporal/cos_configuration.tf
+++ b/modules/charmed-temporal/cos_configuration.tf
@@ -55,7 +55,6 @@ resource "juju_integration" "otel_to_temporal_frontend" {
     name     = local.app_names.temporal_front
     endpoint = local.provides.temporal_front.metrics_endpoint
   }
-  # Static list required by juju provider; whole resource address works for count (0 or 1 instances).
   depends_on = [
     juju_integration.admin_to_worker,
     module.temporal_frontend,

--- a/modules/charmed-temporal/cos_configuration.tf
+++ b/modules/charmed-temporal/cos_configuration.tf
@@ -55,6 +55,7 @@ resource "juju_integration" "otel_to_temporal_frontend" {
     name     = local.app_names.temporal_front
     endpoint = local.provides.temporal_front.metrics_endpoint
   }
+  depends_on = [juju_integration.admin_to_worker]
 }
 
 resource "juju_integration" "otel_to_temporal_history" {
@@ -68,6 +69,7 @@ resource "juju_integration" "otel_to_temporal_history" {
     name     = local.app_names.temporal_hist
     endpoint = local.provides.temporal_hist.metrics_endpoint
   }
+  depends_on = [juju_integration.admin_to_worker]
 }
 
 resource "juju_integration" "otel_to_temporal_matching" {
@@ -81,6 +83,7 @@ resource "juju_integration" "otel_to_temporal_matching" {
     name     = local.app_names.temporal_match
     endpoint = local.provides.temporal_match.metrics_endpoint
   }
+  depends_on = [juju_integration.admin_to_worker]
 }
 
 resource "juju_integration" "otel_to_temporal_worker" {
@@ -94,4 +97,5 @@ resource "juju_integration" "otel_to_temporal_worker" {
     name     = local.app_names.temporal_work
     endpoint = local.provides.temporal_work.metrics_endpoint
   }
+  depends_on = [juju_integration.admin_to_worker]
 }

--- a/modules/charmed-temporal/cos_configuration.tf
+++ b/modules/charmed-temporal/cos_configuration.tf
@@ -55,7 +55,12 @@ resource "juju_integration" "otel_to_temporal_frontend" {
     name     = local.app_names.temporal_front
     endpoint = local.provides.temporal_front.metrics_endpoint
   }
-  depends_on = [juju_integration.admin_to_worker]
+  # Static list required by juju provider; whole resource address works for count (0 or 1 instances).
+  depends_on = [
+    juju_integration.admin_to_worker,
+    module.temporal_frontend,
+    juju_application.otel_collector_k8s,
+  ]
 }
 
 resource "juju_integration" "otel_to_temporal_history" {
@@ -69,7 +74,11 @@ resource "juju_integration" "otel_to_temporal_history" {
     name     = local.app_names.temporal_hist
     endpoint = local.provides.temporal_hist.metrics_endpoint
   }
-  depends_on = [juju_integration.admin_to_worker]
+  depends_on = [
+    juju_integration.admin_to_worker,
+    module.temporal_history,
+    juju_application.otel_collector_k8s,
+  ]
 }
 
 resource "juju_integration" "otel_to_temporal_matching" {
@@ -83,7 +92,11 @@ resource "juju_integration" "otel_to_temporal_matching" {
     name     = local.app_names.temporal_match
     endpoint = local.provides.temporal_match.metrics_endpoint
   }
-  depends_on = [juju_integration.admin_to_worker]
+  depends_on = [
+    juju_integration.admin_to_worker,
+    module.temporal_matching,
+    juju_application.otel_collector_k8s,
+  ]
 }
 
 resource "juju_integration" "otel_to_temporal_worker" {
@@ -97,5 +110,9 @@ resource "juju_integration" "otel_to_temporal_worker" {
     name     = local.app_names.temporal_work
     endpoint = local.provides.temporal_work.metrics_endpoint
   }
-  depends_on = [juju_integration.admin_to_worker]
+  depends_on = [
+    juju_integration.admin_to_worker,
+    module.temporal_worker,
+    juju_application.otel_collector_k8s,
+  ]
 }

--- a/modules/charmed-temporal/cos_configuration.tf
+++ b/modules/charmed-temporal/cos_configuration.tf
@@ -56,7 +56,6 @@ resource "juju_integration" "otel_to_temporal_frontend" {
     endpoint = local.provides.temporal_front.metrics_endpoint
   }
   depends_on = [
-    juju_integration.admin_to_worker,
     module.temporal_frontend,
     juju_application.otel_collector_k8s,
   ]
@@ -74,7 +73,6 @@ resource "juju_integration" "otel_to_temporal_history" {
     endpoint = local.provides.temporal_hist.metrics_endpoint
   }
   depends_on = [
-    juju_integration.admin_to_worker,
     module.temporal_history,
     juju_application.otel_collector_k8s,
   ]
@@ -92,7 +90,6 @@ resource "juju_integration" "otel_to_temporal_matching" {
     endpoint = local.provides.temporal_match.metrics_endpoint
   }
   depends_on = [
-    juju_integration.admin_to_worker,
     module.temporal_matching,
     juju_application.otel_collector_k8s,
   ]
@@ -110,7 +107,6 @@ resource "juju_integration" "otel_to_temporal_worker" {
     endpoint = local.provides.temporal_work.metrics_endpoint
   }
   depends_on = [
-    juju_integration.admin_to_worker,
     module.temporal_worker,
     juju_application.otel_collector_k8s,
   ]

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -1,5 +1,5 @@
-# Explicit depends_on on both charm modules per integration (#18). No juju_integration chaining;
-# parallel destroy is handled in CI via `just destroy` → terraform destroy -parallelism=1.
+# Each integration depends_on the two charm modules it relates (#18). Integrations are not
+# chained to each other. 
 
 # Temporal Frontend ↔ PostgreSQL
 resource "juju_integration" "frontend_to_postgresql" {

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -1,116 +1,130 @@
-# Each integration depends_on the two charm modules it relates (#18). Integrations are not
-# chained to each other. 
+# Each integration depends_on the two charm modules/resources it relates.
+# Temporal services connect to PostgreSQL through PgBouncer (session pooling mode by default),
 
-# Temporal Frontend ↔ PostgreSQL
-resource "juju_integration" "frontend_to_postgresql" {
+# PgBouncer ↔ PostgreSQL (backend)
+resource "juju_integration" "pgbouncer_to_postgresql" {
+  model_uuid = var.model_uuid
+  application {
+    name     = var.postgresql.app_name
+    endpoint = module.postgresql.provides.database
+  }
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "backend-database"
+  }
+  depends_on = [module.postgresql, juju_application.pgbouncer]
+}
+
+# Temporal Frontend ↔ PgBouncer
+resource "juju_integration" "frontend_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-frontend"
     endpoint = module.temporal_frontend.requires.db
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_frontend, module.postgresql]
+  depends_on = [module.temporal_frontend, juju_application.pgbouncer]
 }
 
-# Temporal Frontend ↔ PostgreSQL (visibility)
-resource "juju_integration" "frontend_visibility_to_postgresql" {
+# Temporal Frontend ↔ PgBouncer (visibility)
+resource "juju_integration" "frontend_visibility_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-frontend"
     endpoint = module.temporal_frontend.requires.visibility
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_frontend, module.postgresql]
+  depends_on = [module.temporal_frontend, juju_application.pgbouncer]
 }
 
-# Temporal History ↔ PostgreSQL
-resource "juju_integration" "history_to_postgresql" {
+# Temporal History ↔ PgBouncer
+resource "juju_integration" "history_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-history"
     endpoint = module.temporal_history.requires.db
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_history, module.postgresql]
+  depends_on = [module.temporal_history, juju_application.pgbouncer]
 }
 
-# Temporal Matching ↔ PostgreSQL
-resource "juju_integration" "matching_to_postgresql" {
-  model_uuid = var.model_uuid
-  application {
-    name     = "temporal-matching"
-    endpoint = module.temporal_matching.requires.db
-  }
-  application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
-  }
-  depends_on = [module.temporal_matching, module.postgresql]
-}
-
-# Temporal History ↔ PostgreSQL (visibility)
-resource "juju_integration" "history_visibility_to_postgresql" {
+# Temporal History ↔ PgBouncer (visibility)
+resource "juju_integration" "history_visibility_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-history"
     endpoint = module.temporal_history.requires.visibility
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_history, module.postgresql]
+  depends_on = [module.temporal_history, juju_application.pgbouncer]
 }
 
-# Temporal Matching ↔ PostgreSQL (visibility)
-resource "juju_integration" "matching_visibility_to_postgresql" {
+# Temporal Matching ↔ PgBouncer
+resource "juju_integration" "matching_to_pgbouncer" {
+  model_uuid = var.model_uuid
+  application {
+    name     = "temporal-matching"
+    endpoint = module.temporal_matching.requires.db
+  }
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
+  }
+  depends_on = [module.temporal_matching, juju_application.pgbouncer]
+}
+
+# Temporal Matching ↔ PgBouncer (visibility)
+resource "juju_integration" "matching_visibility_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-matching"
     endpoint = module.temporal_matching.requires.visibility
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_matching, module.postgresql]
+  depends_on = [module.temporal_matching, juju_application.pgbouncer]
 }
 
-# Temporal Worker ↔ PostgreSQL
-resource "juju_integration" "worker_to_postgresql" {
+# Temporal Worker ↔ PgBouncer
+resource "juju_integration" "worker_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-worker"
     endpoint = module.temporal_worker.requires.db
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_worker, module.postgresql]
+  depends_on = [module.temporal_worker, juju_application.pgbouncer]
 }
 
-# Temporal Worker ↔ PostgreSQL (visibility)
-resource "juju_integration" "worker_visibility_to_postgresql" {
+# Temporal Worker ↔ PgBouncer (visibility)
+resource "juju_integration" "worker_visibility_to_pgbouncer" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-worker"
     endpoint = module.temporal_worker.requires.visibility
   }
   application {
-    name     = var.postgresql.app_name
-    endpoint = module.postgresql.provides.database
+    name     = juju_application.pgbouncer.name
+    endpoint = "database"
   }
-  depends_on = [module.temporal_worker, module.postgresql]
+  depends_on = [module.temporal_worker, juju_application.pgbouncer]
 }
 
 # Temporal Frontend ↔ UI

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -141,16 +141,16 @@ resource "juju_integration" "frontend_to_ui" {
   depends_on = [module.temporal_frontend, module.temporal_ui]
 }
 
-# Temporal Frontent ↔ UI (temporal-host-info)
-resource "juju_integration" "frontend_to_ui_host_info"{
+# Temporal Frontend ↔ UI (temporal-host-info)
+resource "juju_integration" "frontend_to_ui_host_info" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-frontend"
-    endpoint = "temporal-host-info"
+    endpoint = module.temporal_frontend.provides.temporal_host_info
   }
   application {
     name     = var.temporal_ui.app_name
-    endpoint = "temporal-host-info"
+    endpoint = module.temporal_ui.requires.temporal_host_info
   }
   depends_on = [module.temporal_frontend, module.temporal_ui]
 }
@@ -174,11 +174,11 @@ resource "juju_integration" "frontend_to_admin_host_info" {
   model_uuid = var.model_uuid
   application {
     name     = "temporal-frontend"
-    endpoint = "temporal-host-info"
+    endpoint = module.temporal_frontend.provides.temporal_host_info
   }
   application {
     name     = var.temporal_admin.app_name
-    endpoint = "temporal-host-info"
+    endpoint = module.temporal_admin.requires.temporal_host_info
   }
   depends_on = [module.temporal_frontend, module.temporal_admin]
 }

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -1,3 +1,6 @@
+# Integrations are ordered with depends_on so PostgreSQL relations are not all applied at once,
+# which avoids exhausting max_connections when many Temporal units connect during setup.
+
 # Temporal Frontend ↔ PostgreSQL
 resource "juju_integration" "frontend_to_postgresql" {
   model_uuid = var.model_uuid
@@ -22,33 +25,9 @@ resource "juju_integration" "frontend_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [juju_integration.frontend_to_postgresql]
 }
 
-# Temporal Frontend ↔ UI
-resource "juju_integration" "frontend_to_ui" {
-  model_uuid = var.model_uuid
-  application {
-    name     = "temporal-frontend"
-    endpoint = module.temporal_frontend.requires.ui
-  }
-  application {
-    name     = var.temporal_ui.app_name
-    endpoint = module.temporal_ui.provides.ui
-  }
-}
-
-# Temporal Frontend ↔ Admin
-resource "juju_integration" "frontend_to_admin" {
-  model_uuid = var.model_uuid
-  application {
-    name     = "temporal-frontend"
-    endpoint = module.temporal_frontend.requires.admin
-  }
-  application {
-    name     = var.temporal_admin.app_name
-    endpoint = module.temporal_admin.provides.admin
-  }
-}
 # Temporal History ↔ PostgreSQL
 resource "juju_integration" "history_to_postgresql" {
   model_uuid = var.model_uuid
@@ -60,6 +39,7 @@ resource "juju_integration" "history_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [juju_integration.frontend_visibility_to_postgresql]
 }
 
 # Temporal Matching ↔ PostgreSQL
@@ -73,6 +53,7 @@ resource "juju_integration" "matching_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [juju_integration.history_to_postgresql]
 }
 
 # Temporal History ↔ PostgreSQL (visibility)
@@ -86,6 +67,7 @@ resource "juju_integration" "history_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [juju_integration.matching_to_postgresql]
 }
 
 # Temporal Matching ↔ PostgreSQL (visibility)
@@ -99,32 +81,7 @@ resource "juju_integration" "matching_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-}
-
-# Temporal Admin ↔ Temporal History
-resource "juju_integration" "admin_to_history" {
-  model_uuid = var.model_uuid
-  application {
-    name     = var.temporal_admin.app_name
-    endpoint = module.temporal_admin.provides.admin
-  }
-  application {
-    name     = "temporal-history"
-    endpoint = module.temporal_history.requires.admin
-  }
-}
-
-# Temporal Admin ↔ Temporal Matching
-resource "juju_integration" "admin_to_matching" {
-  model_uuid = var.model_uuid
-  application {
-    name     = var.temporal_admin.app_name
-    endpoint = module.temporal_admin.provides.admin
-  }
-  application {
-    name     = "temporal-matching"
-    endpoint = module.temporal_matching.requires.admin
-  }
+  depends_on = [juju_integration.history_visibility_to_postgresql]
 }
 
 # Temporal Worker ↔ PostgreSQL
@@ -138,6 +95,7 @@ resource "juju_integration" "worker_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [juju_integration.matching_visibility_to_postgresql]
 }
 
 # Temporal Worker ↔ PostgreSQL (visibility)
@@ -151,6 +109,63 @@ resource "juju_integration" "worker_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [juju_integration.worker_to_postgresql]
+}
+
+# Temporal Frontend ↔ UI (after PostgreSQL integrations to reduce concurrent hook load)
+resource "juju_integration" "frontend_to_ui" {
+  model_uuid = var.model_uuid
+  application {
+    name     = "temporal-frontend"
+    endpoint = module.temporal_frontend.requires.ui
+  }
+  application {
+    name     = var.temporal_ui.app_name
+    endpoint = module.temporal_ui.provides.ui
+  }
+  depends_on = [juju_integration.worker_visibility_to_postgresql]
+}
+
+# Temporal Frontend ↔ Admin
+resource "juju_integration" "frontend_to_admin" {
+  model_uuid = var.model_uuid
+  application {
+    name     = "temporal-frontend"
+    endpoint = module.temporal_frontend.requires.admin
+  }
+  application {
+    name     = var.temporal_admin.app_name
+    endpoint = module.temporal_admin.provides.admin
+  }
+  depends_on = [juju_integration.worker_visibility_to_postgresql]
+}
+
+# Temporal Admin ↔ Temporal History
+resource "juju_integration" "admin_to_history" {
+  model_uuid = var.model_uuid
+  application {
+    name     = var.temporal_admin.app_name
+    endpoint = module.temporal_admin.provides.admin
+  }
+  application {
+    name     = "temporal-history"
+    endpoint = module.temporal_history.requires.admin
+  }
+  depends_on = [juju_integration.frontend_to_admin]
+}
+
+# Temporal Admin ↔ Temporal Matching
+resource "juju_integration" "admin_to_matching" {
+  model_uuid = var.model_uuid
+  application {
+    name     = var.temporal_admin.app_name
+    endpoint = module.temporal_admin.provides.admin
+  }
+  application {
+    name     = "temporal-matching"
+    endpoint = module.temporal_matching.requires.admin
+  }
+  depends_on = [juju_integration.admin_to_history]
 }
 
 # Temporal Admin ↔ Temporal Worker
@@ -164,4 +179,5 @@ resource "juju_integration" "admin_to_worker" {
     name     = "temporal-worker"
     endpoint = module.temporal_worker.requires.admin
   }
+  depends_on = [juju_integration.admin_to_matching]
 }

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -1,4 +1,5 @@
-# Each integration explicitly depends_on the two charm modules it connects (#18).
+# Explicit depends_on on both charm modules per integration (#18). No juju_integration chaining;
+# parallel destroy is handled in CI via `just destroy` → terraform destroy -parallelism=1.
 
 # Temporal Frontend ↔ PostgreSQL
 resource "juju_integration" "frontend_to_postgresql" {

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -1,5 +1,5 @@
-# Integrations are ordered with depends_on so PostgreSQL relations are not all applied at once,
-# which avoids exhausting max_connections when many Temporal units connect during setup.
+# Integrations use explicit depends_on on charm modules (github.com/canonical/charmed-temporal-solutions/issues/18)
+# and chained depends_on between integrations to reduce parallel apply / DB connection spikes.
 
 # Temporal Frontend ↔ PostgreSQL
 resource "juju_integration" "frontend_to_postgresql" {
@@ -12,6 +12,7 @@ resource "juju_integration" "frontend_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
+  depends_on = [module.temporal_frontend, module.postgresql]
 }
 
 # Temporal Frontend ↔ PostgreSQL (visibility)
@@ -25,7 +26,11 @@ resource "juju_integration" "frontend_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.frontend_to_postgresql]
+  depends_on = [
+    module.temporal_frontend,
+    module.postgresql,
+    juju_integration.frontend_to_postgresql,
+  ]
 }
 
 # Temporal History ↔ PostgreSQL
@@ -39,7 +44,11 @@ resource "juju_integration" "history_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.frontend_visibility_to_postgresql]
+  depends_on = [
+    module.temporal_history,
+    module.postgresql,
+    juju_integration.frontend_visibility_to_postgresql,
+  ]
 }
 
 # Temporal Matching ↔ PostgreSQL
@@ -53,7 +62,11 @@ resource "juju_integration" "matching_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.history_to_postgresql]
+  depends_on = [
+    module.temporal_matching,
+    module.postgresql,
+    juju_integration.history_to_postgresql,
+  ]
 }
 
 # Temporal History ↔ PostgreSQL (visibility)
@@ -67,7 +80,11 @@ resource "juju_integration" "history_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.matching_to_postgresql]
+  depends_on = [
+    module.temporal_history,
+    module.postgresql,
+    juju_integration.matching_to_postgresql,
+  ]
 }
 
 # Temporal Matching ↔ PostgreSQL (visibility)
@@ -81,7 +98,11 @@ resource "juju_integration" "matching_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.history_visibility_to_postgresql]
+  depends_on = [
+    module.temporal_matching,
+    module.postgresql,
+    juju_integration.history_visibility_to_postgresql,
+  ]
 }
 
 # Temporal Worker ↔ PostgreSQL
@@ -95,7 +116,11 @@ resource "juju_integration" "worker_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.matching_visibility_to_postgresql]
+  depends_on = [
+    module.temporal_worker,
+    module.postgresql,
+    juju_integration.matching_visibility_to_postgresql,
+  ]
 }
 
 # Temporal Worker ↔ PostgreSQL (visibility)
@@ -109,7 +134,11 @@ resource "juju_integration" "worker_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [juju_integration.worker_to_postgresql]
+  depends_on = [
+    module.temporal_worker,
+    module.postgresql,
+    juju_integration.worker_to_postgresql,
+  ]
 }
 
 # Temporal Frontend ↔ UI (after PostgreSQL integrations to reduce concurrent hook load)
@@ -123,7 +152,11 @@ resource "juju_integration" "frontend_to_ui" {
     name     = var.temporal_ui.app_name
     endpoint = module.temporal_ui.provides.ui
   }
-  depends_on = [juju_integration.worker_visibility_to_postgresql]
+  depends_on = [
+    module.temporal_frontend,
+    module.temporal_ui,
+    juju_integration.worker_visibility_to_postgresql,
+  ]
 }
 
 # Temporal Frontend ↔ Admin
@@ -137,7 +170,11 @@ resource "juju_integration" "frontend_to_admin" {
     name     = var.temporal_admin.app_name
     endpoint = module.temporal_admin.provides.admin
   }
-  depends_on = [juju_integration.worker_visibility_to_postgresql]
+  depends_on = [
+    module.temporal_frontend,
+    module.temporal_admin,
+    juju_integration.worker_visibility_to_postgresql,
+  ]
 }
 
 # Temporal Admin ↔ Temporal History
@@ -151,7 +188,11 @@ resource "juju_integration" "admin_to_history" {
     name     = "temporal-history"
     endpoint = module.temporal_history.requires.admin
   }
-  depends_on = [juju_integration.frontend_to_admin]
+  depends_on = [
+    module.temporal_admin,
+    module.temporal_history,
+    juju_integration.frontend_to_admin,
+  ]
 }
 
 # Temporal Admin ↔ Temporal Matching
@@ -165,7 +206,11 @@ resource "juju_integration" "admin_to_matching" {
     name     = "temporal-matching"
     endpoint = module.temporal_matching.requires.admin
   }
-  depends_on = [juju_integration.admin_to_history]
+  depends_on = [
+    module.temporal_admin,
+    module.temporal_matching,
+    juju_integration.admin_to_history,
+  ]
 }
 
 # Temporal Admin ↔ Temporal Worker
@@ -179,5 +224,9 @@ resource "juju_integration" "admin_to_worker" {
     name     = "temporal-worker"
     endpoint = module.temporal_worker.requires.admin
   }
-  depends_on = [juju_integration.admin_to_matching]
+  depends_on = [
+    module.temporal_admin,
+    module.temporal_worker,
+    juju_integration.admin_to_matching,
+  ]
 }

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -1,5 +1,4 @@
-# Integrations use explicit depends_on on charm modules (github.com/canonical/charmed-temporal-solutions/issues/18)
-# and chained depends_on between integrations to reduce parallel apply / DB connection spikes.
+# Each integration explicitly depends_on the two charm modules it connects (#18).
 
 # Temporal Frontend ↔ PostgreSQL
 resource "juju_integration" "frontend_to_postgresql" {
@@ -26,11 +25,7 @@ resource "juju_integration" "frontend_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_frontend,
-    module.postgresql,
-    juju_integration.frontend_to_postgresql,
-  ]
+  depends_on = [module.temporal_frontend, module.postgresql]
 }
 
 # Temporal History ↔ PostgreSQL
@@ -44,11 +39,7 @@ resource "juju_integration" "history_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_history,
-    module.postgresql,
-    juju_integration.frontend_visibility_to_postgresql,
-  ]
+  depends_on = [module.temporal_history, module.postgresql]
 }
 
 # Temporal Matching ↔ PostgreSQL
@@ -62,11 +53,7 @@ resource "juju_integration" "matching_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_matching,
-    module.postgresql,
-    juju_integration.history_to_postgresql,
-  ]
+  depends_on = [module.temporal_matching, module.postgresql]
 }
 
 # Temporal History ↔ PostgreSQL (visibility)
@@ -80,11 +67,7 @@ resource "juju_integration" "history_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_history,
-    module.postgresql,
-    juju_integration.matching_to_postgresql,
-  ]
+  depends_on = [module.temporal_history, module.postgresql]
 }
 
 # Temporal Matching ↔ PostgreSQL (visibility)
@@ -98,11 +81,7 @@ resource "juju_integration" "matching_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_matching,
-    module.postgresql,
-    juju_integration.history_visibility_to_postgresql,
-  ]
+  depends_on = [module.temporal_matching, module.postgresql]
 }
 
 # Temporal Worker ↔ PostgreSQL
@@ -116,11 +95,7 @@ resource "juju_integration" "worker_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_worker,
-    module.postgresql,
-    juju_integration.matching_visibility_to_postgresql,
-  ]
+  depends_on = [module.temporal_worker, module.postgresql]
 }
 
 # Temporal Worker ↔ PostgreSQL (visibility)
@@ -134,14 +109,10 @@ resource "juju_integration" "worker_visibility_to_postgresql" {
     name     = var.postgresql.app_name
     endpoint = module.postgresql.provides.database
   }
-  depends_on = [
-    module.temporal_worker,
-    module.postgresql,
-    juju_integration.worker_to_postgresql,
-  ]
+  depends_on = [module.temporal_worker, module.postgresql]
 }
 
-# Temporal Frontend ↔ UI (after PostgreSQL integrations to reduce concurrent hook load)
+# Temporal Frontend ↔ UI
 resource "juju_integration" "frontend_to_ui" {
   model_uuid = var.model_uuid
   application {
@@ -152,11 +123,7 @@ resource "juju_integration" "frontend_to_ui" {
     name     = var.temporal_ui.app_name
     endpoint = module.temporal_ui.provides.ui
   }
-  depends_on = [
-    module.temporal_frontend,
-    module.temporal_ui,
-    juju_integration.worker_visibility_to_postgresql,
-  ]
+  depends_on = [module.temporal_frontend, module.temporal_ui]
 }
 
 # Temporal Frontend ↔ Admin
@@ -170,11 +137,7 @@ resource "juju_integration" "frontend_to_admin" {
     name     = var.temporal_admin.app_name
     endpoint = module.temporal_admin.provides.admin
   }
-  depends_on = [
-    module.temporal_frontend,
-    module.temporal_admin,
-    juju_integration.worker_visibility_to_postgresql,
-  ]
+  depends_on = [module.temporal_frontend, module.temporal_admin]
 }
 
 # Temporal Admin ↔ Temporal History
@@ -188,11 +151,7 @@ resource "juju_integration" "admin_to_history" {
     name     = "temporal-history"
     endpoint = module.temporal_history.requires.admin
   }
-  depends_on = [
-    module.temporal_admin,
-    module.temporal_history,
-    juju_integration.frontend_to_admin,
-  ]
+  depends_on = [module.temporal_admin, module.temporal_history]
 }
 
 # Temporal Admin ↔ Temporal Matching
@@ -206,11 +165,7 @@ resource "juju_integration" "admin_to_matching" {
     name     = "temporal-matching"
     endpoint = module.temporal_matching.requires.admin
   }
-  depends_on = [
-    module.temporal_admin,
-    module.temporal_matching,
-    juju_integration.admin_to_history,
-  ]
+  depends_on = [module.temporal_admin, module.temporal_matching]
 }
 
 # Temporal Admin ↔ Temporal Worker
@@ -224,9 +179,5 @@ resource "juju_integration" "admin_to_worker" {
     name     = "temporal-worker"
     endpoint = module.temporal_worker.requires.admin
   }
-  depends_on = [
-    module.temporal_admin,
-    module.temporal_worker,
-    juju_integration.admin_to_matching,
-  ]
+  depends_on = [module.temporal_admin, module.temporal_worker]
 }

--- a/modules/charmed-temporal/integrations.tf
+++ b/modules/charmed-temporal/integrations.tf
@@ -141,6 +141,20 @@ resource "juju_integration" "frontend_to_ui" {
   depends_on = [module.temporal_frontend, module.temporal_ui]
 }
 
+# Temporal Frontent ↔ UI (temporal-host-info)
+resource "juju_integration" "frontend_to_ui_host_info"{
+  model_uuid = var.model_uuid
+  application {
+    name     = "temporal-frontend"
+    endpoint = "temporal-host-info"
+  }
+  application {
+    name     = var.temporal_ui.app_name
+    endpoint = "temporal-host-info"
+  }
+  depends_on = [module.temporal_frontend, module.temporal_ui]
+}
+
 # Temporal Frontend ↔ Admin
 resource "juju_integration" "frontend_to_admin" {
   model_uuid = var.model_uuid
@@ -151,6 +165,20 @@ resource "juju_integration" "frontend_to_admin" {
   application {
     name     = var.temporal_admin.app_name
     endpoint = module.temporal_admin.provides.admin
+  }
+  depends_on = [module.temporal_frontend, module.temporal_admin]
+}
+
+# Temporal Frontend ↔ Admin (temporal-host-info)
+resource "juju_integration" "frontend_to_admin_host_info" {
+  model_uuid = var.model_uuid
+  application {
+    name     = "temporal-frontend"
+    endpoint = "temporal-host-info"
+  }
+  application {
+    name     = var.temporal_admin.app_name
+    endpoint = "temporal-host-info"
   }
   depends_on = [module.temporal_frontend, module.temporal_admin]
 }

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -95,3 +95,7 @@ test:
     just apply "./test/terraform_test.tfvars"
 
     just wait-for-active
+
+    juju status
+
+    juju debug-log

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -90,7 +90,7 @@ destroy-with-overlay base_file overlay_file:
     terraform destroy -auto-approve -var-file="${base_file}" -var-file="${overlay_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
-    rm -f "${base_file}"
+    sed -i '/^model_uuid[[:space:]]*=/d' "${base_file}" || true
 
 # Port-forward otel-collector and run goss COS tests
 [private]
@@ -127,13 +127,15 @@ test-cos:
     #!/usr/bin/bash
     set -euxo pipefail
 
-    trap 'just destroy-with-overlay "terraform_test.tfvars" "test/terraform_cos.tfvars"' EXIT
+    trap 'just destroy-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos.tfvars"' EXIT
 
     just add-model
 
-    just validate_test_tfvars "terraform_test.tfvars"
+    rm -f terraform.tfstate terraform.tfstate.backup
 
-    just apply-with-overlay "terraform_test.tfvars" "test/terraform_cos.tfvars"
+    just validate_test_tfvars "./test/terraform_test.tfvars"
+
+    just apply-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos.tfvars"
 
     juju wait-for model temporal-test --timeout=600s || true
 
@@ -146,16 +148,18 @@ test-cos-existing:
     #!/usr/bin/bash
     set -euxo pipefail
 
-    trap 'just destroy-with-overlay "terraform_test.tfvars" "test/terraform_cos_existing.tfvars"' EXIT
+    trap 'just destroy-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos_existing.tfvars"' EXIT
 
     just add-model
 
-    just validate_test_tfvars "terraform_test.tfvars"
+    rm -f terraform.tfstate terraform.tfstate.backup
+
+    just validate_test_tfvars "./test/terraform_test.tfvars"
 
     juju deploy opentelemetry-collector-k8s otel-collector --channel=2/stable --trust -m temporal-test
     juju wait-for application otel-collector --model temporal-test --timeout=300s || true
 
-    just apply-with-overlay "terraform_test.tfvars" "test/terraform_cos_existing.tfvars"
+    just apply-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos_existing.tfvars"
 
     juju wait-for model temporal-test --timeout=600s || true
 

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -29,6 +29,15 @@ validate_test_tfvars variables_file:
         exit 1
     fi
     echo "model_uuid = \"${MODEL_UUID}\"" > "${variables_file}"
+    cat >> "${variables_file}" <<'EOF'
+
+# CI / local test: higher PostgreSQL connection headroom (postgresql-k8s charm).
+postgresql = {
+  config = {
+    profile = "testing"
+  }
+}
+EOF
 
 # Terraform fmt
 fmt: (initialize)

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -29,7 +29,6 @@ validate_test_tfvars variables_file:
         exit 1
     fi
     echo "model_uuid = \"${MODEL_UUID}\"" > "${variables_file}"
-    # Use echo, not a heredoc: `just` parses recipe lines and rejects `postgresql = {` inside heredocs.
     {
       echo ""
       echo "# CI / local test: higher PostgreSQL connection headroom (postgresql-k8s charm)."

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -137,7 +137,7 @@ test-cos:
 
     just apply-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos.tfvars"
 
-    juju wait-for model temporal-test --timeout=600s || true
+    just wait-for-active
 
     juju wait-for application otel-collector --model temporal-test --timeout=300s || true
 
@@ -161,6 +161,6 @@ test-cos-existing:
 
     just apply-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos_existing.tfvars"
 
-    juju wait-for model temporal-test --timeout=600s || true
+    just wait-for-active
 
     just goss-cos

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -53,7 +53,7 @@ destroy variables_file:
     if [ ! -f "${variables_file}" ]; then
         exit 1
     fi
-    terraform destroy -auto-approve -var-file="${variables_file}" || true
+    terraform destroy -auto-approve -parallelism=1 -var-file="${variables_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
 
@@ -86,7 +86,7 @@ apply-with-overlay base_file overlay_file: (initialize)
 destroy-with-overlay base_file overlay_file:
     #!/usr/bin/bash
     set -euxo pipefail
-    terraform destroy -auto-approve -var-file="${base_file}" -var-file="${overlay_file}" || true
+    terraform destroy -auto-approve -parallelism=1 -var-file="${base_file}" -var-file="${overlay_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
     rm -f "${base_file}"

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -28,16 +28,8 @@ validate_test_tfvars variables_file:
     if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
         exit 1
     fi
-    echo "model_uuid = \"${MODEL_UUID}\"" > "${variables_file}"
-    {
-      echo ""
-      echo "# CI / local test: higher PostgreSQL connection headroom (postgresql-k8s charm)."
-      echo "postgresql = {"
-      echo "  config = {"
-      echo "    profile = \"testing\""
-      echo "  }"
-      echo "}"
-    } >> "${variables_file}"
+    cp test/terraform_test.tfvars "${variables_file}"
+    printf '\nmodel_uuid = "%s"\n' "${MODEL_UUID}" >> "${variables_file}"
 
 # Terraform fmt
 fmt: (initialize)

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -28,7 +28,8 @@ validate_test_tfvars variables_file:
     if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
         exit 1
     fi
-    printf '\nmodel_uuid = "%s"\n' "${MODEL_UUID}" >> "${variables_file}"
+    echo >> "${variables_file}"
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
 
 # Terraform fmt
 fmt: (initialize)
@@ -53,7 +54,7 @@ destroy variables_file:
     if [ ! -f "${variables_file}" ]; then
         exit 1
     fi
-    terraform destroy -auto-approve -parallelism=2 -var-file="${variables_file}" || true
+    terraform destroy -auto-approve -var-file="${variables_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
 
@@ -86,7 +87,7 @@ apply-with-overlay base_file overlay_file: (initialize)
 destroy-with-overlay base_file overlay_file:
     #!/usr/bin/bash
     set -euxo pipefail
-    terraform destroy -auto-approve -parallelism=2 -var-file="${base_file}" -var-file="${overlay_file}" || true
+    terraform destroy -auto-approve -var-file="${base_file}" -var-file="${overlay_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
     rm -f "${base_file}"

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -20,6 +20,7 @@ add-model: (destroy-model)
     juju add-model temporal-test
 
 [private]
+# Appends model_uuid to variables_file (does not copy). Requires Juju model temporal-test.
 validate_test_tfvars variables_file:
     #!/usr/bin/bash
 
@@ -86,6 +87,9 @@ test:
     trap 'just destroy "./test/terraform_test.tfvars"' EXIT
 
     just add-model
+
+    # Fresh model UUID each run; stale terraform.tfstate still references the old model → refresh fails.
+    rm -f terraform.tfstate terraform.tfstate.backup
 
     just validate_test_tfvars "./test/terraform_test.tfvars"
 

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -19,7 +19,6 @@ destroy-model:
 add-model: (destroy-model)
     juju add-model temporal-test
 
-[private]
 # Appends model_uuid to variables_file (does not copy). Requires Juju model temporal-test.
 validate_test_tfvars variables_file:
     #!/usr/bin/bash

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -60,23 +60,34 @@ destroy variables_file:
 
     sed -i '/^model_uuid[[:space:]]*=/d' "${variables_file}" || true
 
-# Wait for all applications in temporal-test to reach active status
-wait-for-active:
+# Wait for all applications in temporal-test to reach active status.
+# Pass application names as positional args to exclude them from the active check
+# (e.g. otel-collector, which is expected to stay blocked until the consumer wires their COS).
+wait-for-active *excluded:
     #!/usr/bin/env bash
     set -euxo pipefail
+
+    query='forEach(applications, app => app.status == "active")'
+    if [ -n "{{ excluded }}" ]; then
+        clause=""
+        for app in {{ excluded }}; do
+            clause="${clause:+$clause || }app.name == \"$app\""
+        done
+        query="forEach(applications, app => ($clause) || app.status == \"active\")"
+    fi
 
     timeout=1200
     elapsed=0
     interval=10
     while [ $elapsed -lt $timeout ]; do
         if juju wait-for model temporal-test \
-            --query='forEach(applications, app => app.status == "active")' \
+            --query="$query" \
             --timeout=${interval}s 2>/dev/null; then
             exit 0
         fi
         elapsed=$((elapsed + interval))
     done
-    echo "Timed out waiting for all applications to become active"
+    echo "Timed out waiting for applications (excluding: {{ excluded }}) to become active"
     exit 1
 
 # Apply with a base variables file and an overlay variables file
@@ -137,9 +148,14 @@ test-cos:
 
     just apply-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos.tfvars"
 
-    just wait-for-active
-
-    juju wait-for application otel-collector --model temporal-test --timeout=300s || true
+    # otel-collector is expected to end up blocked on the mandatory-relation pair check:
+    # `metrics-endpoint` has peers but `send-remote-write`/`cloud-config` don't. The sink
+    # is the consumer's responsibility, so we assert the specific blocked message rather
+    # than treating it as a failure. Workload health is validated separately via goss-cos.
+    just wait-for-active otel-collector
+    juju wait-for unit otel-collector/0 --model temporal-test \
+        --query="workload-status==\"blocked\" && workload-message==\"['cloud-config']|['send-remote-write'] for metrics-endpoint\"" \
+        --timeout=300s
 
     just goss-cos
 
@@ -157,10 +173,20 @@ test-cos-existing:
     just validate_test_tfvars "./test/terraform_test.tfvars"
 
     juju deploy opentelemetry-collector-k8s otel-collector --channel=2/stable --trust -m temporal-test
-    juju wait-for application otel-collector --model temporal-test --timeout=300s || true
+    # Before the module adds metrics-endpoint integrations, the bare collector has no mandatory
+    # pairs missing and should reach active on its own.
+    juju wait-for application otel-collector --model temporal-test \
+        --query='status=="active"' --timeout=300s
 
     just apply-with-overlay "./test/terraform_test.tfvars" "test/terraform_cos_existing.tfvars"
 
-    just wait-for-active
+    # After apply, the four temporal ↔ otel-collector `metrics-endpoint` relations exist but
+    # no `send-remote-write`/`cloud-config` peer does, so the charm's mandatory-pair check
+    # blocks the unit by design. Assert the exact blocked message to document the contract:
+    # the COS sink is the consumer's responsibility.
+    just wait-for-active otel-collector
+    juju wait-for unit otel-collector/0 --model temporal-test \
+        --query="workload-status==\"blocked\" && workload-message==\"['cloud-config']|['send-remote-write'] for metrics-endpoint\"" \
+        --timeout=300s
 
     just goss-cos

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -98,4 +98,4 @@ test:
 
     juju status
 
-    juju debug-log
+    juju debug-log --replay

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -28,7 +28,6 @@ validate_test_tfvars variables_file:
     if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
         exit 1
     fi
-    cp test/terraform_test.tfvars "${variables_file}"
     printf '\nmodel_uuid = "%s"\n' "${MODEL_UUID}" >> "${variables_file}"
 
 # Terraform fmt
@@ -54,24 +53,42 @@ destroy variables_file:
     if [ ! -f "${variables_file}" ]; then
         exit 1
     fi
-    # Serial destroy avoids parallel juju_integration teardown timeouts in CI (provider max duration).
-    terraform destroy -auto-approve -parallelism=1 -var-file="${variables_file}" || true
+    terraform destroy -auto-approve -var-file="${variables_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
 
-    rm "${variables_file}"
+    sed -i '/^model_uuid[[:space:]]*=/d' "${variables_file}"
 
-# Full test (create model, apply, wait, cleanup)
+# Wait for all applications in temporal-test to reach active status
+wait-for-active:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
+    timeout=1200
+    elapsed=0
+    interval=10
+    while [ $elapsed -lt $timeout ]; do
+        if juju wait-for model temporal-test \
+            --query='forEach(applications, app => app.status == "active")' \
+            --timeout=${interval}s 2>/dev/null; then
+            exit 0
+        fi
+        elapsed=$((elapsed + interval))
+    done
+    echo "Timed out waiting for all applications to become active"
+    exit 1
+
+# Full test (create model, apply, wait for all apps active, cleanup)
 test:
     #!/usr/bin/bash
     set -euxo pipefail
 
-    trap 'just destroy "terraform_test.tfvars"' EXIT
+    trap 'just destroy "./test/terraform_test.tfvars"' EXIT
 
     just add-model
 
-    just validate_test_tfvars "terraform_test.tfvars"
+    just validate_test_tfvars "./test/terraform_test.tfvars"
 
-    just apply "terraform_test.tfvars"
+    just apply "./test/terraform_test.tfvars"
 
-    juju wait-for model temporal-test --timeout=600s || true
+    just wait-for-active

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -13,7 +13,7 @@ initialize:
 
 # Destroy model if exists
 destroy-model:
-    juju destroy-model --no-prompt --destroy-storage temporal-test || true
+    juju destroy-model temporal-test --no-prompt --destroy-storage --force || true
 
 # Add a fresh model
 add-model: (destroy-model)
@@ -54,9 +54,9 @@ destroy variables_file:
     if [ ! -f "${variables_file}" ]; then
         exit 1
     fi
-    terraform destroy -auto-approve -var-file="${variables_file}" || true
+    terraform destroy -auto-approve -parallelism=1 -var-file="${variables_file}" || true
     echo "Forcing model cleanup..."
-    juju destroy-model --no-prompt --destroy-storage temporal-test || true
+    juju destroy-model temporal-test --no-prompt --destroy-storage --force || true
 
     sed -i '/^model_uuid[[:space:]]*=/d' "${variables_file}" || true
 
@@ -89,7 +89,7 @@ destroy-with-overlay base_file overlay_file:
     set -euxo pipefail
     terraform destroy -auto-approve -var-file="${base_file}" -var-file="${overlay_file}" || true
     echo "Forcing model cleanup..."
-    juju destroy-model --no-prompt --destroy-storage temporal-test || true
+    juju destroy-model temporal-test --no-prompt --destroy-storage --force || true
     sed -i '/^model_uuid[[:space:]]*=/d' "${base_file}" || true
 
 # Port-forward otel-collector and run goss COS tests

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -54,7 +54,8 @@ destroy variables_file:
     if [ ! -f "${variables_file}" ]; then
         exit 1
     fi
-    terraform destroy -auto-approve -var-file="${variables_file}" || true
+    # Serial destroy avoids parallel juju_integration teardown timeouts in CI (provider max duration).
+    terraform destroy -auto-approve -parallelism=1 -var-file="${variables_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
 

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -53,7 +53,7 @@ destroy variables_file:
     if [ ! -f "${variables_file}" ]; then
         exit 1
     fi
-    terraform destroy -auto-approve -parallelism=1 -var-file="${variables_file}" || true
+    terraform destroy -auto-approve -parallelism=2 -var-file="${variables_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
 
@@ -86,7 +86,7 @@ apply-with-overlay base_file overlay_file: (initialize)
 destroy-with-overlay base_file overlay_file:
     #!/usr/bin/bash
     set -euxo pipefail
-    terraform destroy -auto-approve -parallelism=1 -var-file="${base_file}" -var-file="${overlay_file}" || true
+    terraform destroy -auto-approve -parallelism=2 -var-file="${base_file}" -var-file="${overlay_file}" || true
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
     rm -f "${base_file}"
@@ -120,8 +120,6 @@ test:
     just wait-for-active
 
     juju status
-
-    juju debug-log --replay
 
 # Full test for COS with module-deployed opentelemetry-collector-k8s
 test-cos:

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -29,15 +29,16 @@ validate_test_tfvars variables_file:
         exit 1
     fi
     echo "model_uuid = \"${MODEL_UUID}\"" > "${variables_file}"
-    cat >> "${variables_file}" <<'EOF'
-
-# CI / local test: higher PostgreSQL connection headroom (postgresql-k8s charm).
-postgresql = {
-  config = {
-    profile = "testing"
-  }
-}
-EOF
+    # Use echo, not a heredoc: `just` parses recipe lines and rejects `postgresql = {` inside heredocs.
+    {
+      echo ""
+      echo "# CI / local test: higher PostgreSQL connection headroom (postgresql-k8s charm)."
+      echo "postgresql = {"
+      echo "  config = {"
+      echo "    profile = \"testing\""
+      echo "  }"
+      echo "}"
+    } >> "${variables_file}"
 
 # Terraform fmt
 fmt: (initialize)

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -57,7 +57,7 @@ destroy variables_file:
     echo "Forcing model cleanup..."
     juju destroy-model --no-prompt --destroy-storage temporal-test || true
 
-    sed -i '/^model_uuid[[:space:]]*=/d' "${variables_file}"
+    sed -i '/^model_uuid[[:space:]]*=/d' "${variables_file}" || true
 
 # Wait for all applications in temporal-test to reach active status
 wait-for-active:
@@ -119,7 +119,7 @@ test:
 
     just wait-for-active
 
-    juju status
+    juju status || true
 
 # Full test for COS with module-deployed opentelemetry-collector-k8s
 test-cos:

--- a/modules/charmed-temporal/outputs.tf
+++ b/modules/charmed-temporal/outputs.tf
@@ -1,7 +1,8 @@
 output "applications" {
   description = "All charm modules which make up this product module."
   value = {
-    postgresql = module.postgresql
+    postgresql  = module.postgresql
+    pgbouncer   = juju_application.pgbouncer
     temporal = {
       frontend = module.temporal_frontend
       history  = module.temporal_history

--- a/modules/charmed-temporal/test/terraform_test.tfvars
+++ b/modules/charmed-temporal/test/terraform_test.tfvars
@@ -1,8 +1,6 @@
 # Base vars for CI / local `just test`. `validate_test_tfvars` appends `model_uuid`.
-# Higher PostgreSQL connection headroom (postgresql-k8s charm).
 postgresql = {
   config = {
-    profile                      = "testing"
-    experimental_max_connections = "400"
+    profile = "testing"
   }
 }

--- a/modules/charmed-temporal/test/terraform_test.tfvars
+++ b/modules/charmed-temporal/test/terraform_test.tfvars
@@ -1,0 +1,7 @@
+# Base vars for CI / local `just test`. `validate_test_tfvars` appends `model_uuid`.
+# Higher PostgreSQL connection headroom (postgresql-k8s charm).
+postgresql = {
+  config = {
+    profile = "testing"
+  }
+}

--- a/modules/charmed-temporal/test/terraform_test.tfvars
+++ b/modules/charmed-temporal/test/terraform_test.tfvars
@@ -1,6 +1,22 @@
 # Base vars for CI / local `just test`. `validate_test_tfvars` appends `model_uuid`.
+temporal_server = {
+    config = {
+     num-history-shards         = "1"
+     persistence-max-conns      = "6"
+     persistence-max-idle-conns = "4"
+     visibility-max-conns       = "3"
+     visibility-max-idle-conns  = "2"
+   }
+}
+
+pgbouncer = {
+    config = {
+     max_db_connections = "25"
+   }
+}
+
 postgresql = {
-  config = {
-    profile = "testing"
-  }
+    config = {
+     profile = "testing"
+   }
 }

--- a/modules/charmed-temporal/test/terraform_test.tfvars
+++ b/modules/charmed-temporal/test/terraform_test.tfvars
@@ -2,6 +2,7 @@
 # Higher PostgreSQL connection headroom (postgresql-k8s charm).
 postgresql = {
   config = {
-    profile = "testing"
+    profile                      = "testing"
+    experimental_max_connections = "400"
   }
 }

--- a/modules/charmed-temporal/variables.tf
+++ b/modules/charmed-temporal/variables.tf
@@ -53,6 +53,18 @@ variable "temporal_admin" {
   default = {}
 }
 
+variable "pgbouncer" {
+  description = "Inputs for pgbouncer-k8s charm."
+  type = object({
+    app_name = optional(string, "pgbouncer")
+    channel  = optional(string, "1/stable")
+    revision = optional(number, null)
+    units    = optional(number, 1)
+    config   = optional(map(string), {})
+  })
+  default = {}
+}
+
 variable "cos_configuration" {
   description = "Boolean value that enables COS integration."
   type        = bool


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR addresses flaky terraform apply behaviour in CI / small test models (parallel Juju integrations stressing PostgreSQL and occasional “applications were not available” style errors)
- Explicit `depends_on` on the two charm `module.*` sides for each `juju_integration`, as in [#18](https://github.com/canonical/charmed-temporal-solutions/issues/18)
- `modules/charmed-temporal/test/terraform_test.tfvars` sets `postgresql.config.profile = "testing"`. `validate_test_tfvars` copies that file to the output path and appends model_uuid from the temporal-test Juju model

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #19 
Closes #18 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [X] Documentation updated
