### PR TITLE
[WF-399] Update Terraform Solution - Temporal Channel to 1.23/stable

### DIFF
--- a/modules/charmed-temporal/variables.tf
+++ b/modules/charmed-temporal/variables.tf
@@ -7,7 +7,7 @@ variable "temporal_server" {
   description = "Inputs for temporal-k8s charm module."
   type = object({
     app_name = optional(string, "temporal-server")
-    channel  = optional(string, "1.23/edge")
+    channel  = optional(string, "1.23/stable")
     revision = optional(number, 0)
     units    = optional(number, 1)
     config   = optional(map(string), { num-history-shards = "1" })
@@ -33,7 +33,7 @@ variable "temporal_ui" {
   description = "Inputs for temporal-ui-k8s charm module."
   type = object({
     app_name = optional(string, "temporal-ui")
-    channel  = optional(string, "1.23/edge")
+    channel  = optional(string, "1.23/stable")
     revision = optional(number, 0)
     units    = optional(number, 1)
     config   = optional(map(string), {})
@@ -45,7 +45,7 @@ variable "temporal_admin" {
   description = "Inputs for temporal-admin-k8s charm module."
   type = object({
     app_name = optional(string, "temporal-admin")
-    channel  = optional(string, "1.23/edge")
+    channel  = optional(string, "1.23/stable")
     revision = optional(number, 0)
     units    = optional(number, 1)
     config   = optional(map(string), {})


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
changes made:
- Pinned temporal charms channel in the terraform module to `1.23/stable`.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
