### PR TITLE
fix(charmed-temporal): deploy as independent services rather than monoliths

### DIFF
--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -163,7 +163,7 @@ Paths are relative to `modules/charmed-temporal`.
 
 ### Local / CI test flow
 
-`just test` runs `add-model`, removes local `terraform.tfstate` (so the new model UUID never clashes with a previous run), `validate_test_tfvars`, `apply`, then **`just wait-for-active`** (polls until every application in `temporal-test` is `active`, up to 20 minutes). It registers `just destroy` on exit so the model and tfvars line are cleaned up.
+`just test` runs `add-model`, removes local `terraform.tfstate` (so the new model UUID never clashes with a previous run), `validate_test_tfvars`, `apply`, then **`just wait-for-active`** (polls until every application in `temporal-test` is `active`, up to 40 minutes). It registers `just destroy` on exit so the model and tfvars line are cleaned up.
 
 ---
 

--- a/modules/charmed-temporal/README.md
+++ b/modules/charmed-temporal/README.md
@@ -44,6 +44,8 @@ The solution module exposes the following configurable inputs:
 
 Each of the charm input objects (`postgresql`, `pgbouncer`, `temporal_server`, `temporal_ui`, `temporal_admin`) supports the following fields:
 
+> **Note:** For `temporal_server`, the `services` config option of the `temporal-k8s` charm is set automatically per application (`temporal-frontend` → `frontend`, `temporal-history` → `history`, `temporal-matching` → `matching`, `temporal-worker` → `worker`) so that each deploys as an independent microservice. Any `services` value supplied via `temporal_server.config` is overridden.
+
 | Field                | Type                   | Description                                                | Default                                                                                              |
 | -------------------- | ---------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `app_name`           | string                 | Application name to deploy                                 | Charm-specific                                                                                       |

--- a/modules/charmed-temporal/applications.tf
+++ b/modules/charmed-temporal/applications.tf
@@ -29,7 +29,7 @@ module "temporal_frontend" {
   app_name   = "temporal-frontend"
   channel    = var.temporal_server.channel
   units      = var.temporal_server.units
-  config     = var.temporal_server.config
+  config     = merge(var.temporal_server.config, { services = "frontend" })
 }
 
 module "temporal_history" {
@@ -38,7 +38,7 @@ module "temporal_history" {
   app_name   = "temporal-history"
   channel    = var.temporal_server.channel
   units      = var.temporal_server.units
-  config     = var.temporal_server.config
+  config     = merge(var.temporal_server.config, { services = "history" })
 }
 
 module "temporal_matching" {
@@ -47,7 +47,7 @@ module "temporal_matching" {
   app_name   = "temporal-matching"
   channel    = var.temporal_server.channel
   units      = var.temporal_server.units
-  config     = var.temporal_server.config
+  config     = merge(var.temporal_server.config, { services = "matching" })
 }
 
 module "temporal_worker" {
@@ -56,7 +56,7 @@ module "temporal_worker" {
   app_name   = "temporal-worker"
   channel    = var.temporal_server.channel
   units      = var.temporal_server.units
-  config     = var.temporal_server.config
+  config     = merge(var.temporal_server.config, { services = "worker" })
 }
 
 module "temporal_ui" {

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -76,7 +76,11 @@ wait-for-active *excluded:
         query="forEach(applications, app => ($clause) || app.status == \"active\")"
     fi
 
-    timeout=1200
+    # Raised to 2400s so Juju's automatic-hook-retry has time to self-heal the
+    # temporal servers, which transiently fail `db-relation-changed` on a cold
+    # deploy until temporal-admin finishes DB schema setup. See:
+    # https://github.com/canonical/temporal-k8s-operator/issues/133
+    timeout=2400
     elapsed=0
     interval=10
     while [ $elapsed -lt $timeout ]; do

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -103,6 +103,13 @@ destroy-with-overlay base_file overlay_file:
     juju destroy-model temporal-test --no-prompt --destroy-storage --force || true
     sed -i '/^model_uuid[[:space:]]*=/d' "${base_file}" || true
 
+# Run goss tests asserting each temporal-k8s unit runs only its configured service
+[private]
+goss-services:
+    #!/usr/bin/bash
+    set -euxo pipefail
+    GOSS_FILE=test/goss-services.yaml goss validate --retry-timeout 30s
+
 # Port-forward otel-collector and run goss COS tests
 [private]
 goss-cos:
@@ -130,6 +137,8 @@ test:
     just apply "./test/terraform_test.tfvars"
 
     just wait-for-active
+
+    just goss-services
 
     juju status || true
 

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -18,8 +18,8 @@ destroy-model:
 # Add a fresh model
 add-model: (destroy-model)
     juju add-model temporal-test
-    # Concierge's k8s preset bootstraps with automatically-retry-hooks=false; re-enable so the
-    # temporal servers self-heal the transient db-relation-changed failure on a cold deploy. See:
+    # Concierge's k8s preset bootstraps with automatically-retry-hooks=false;
+    # We need to override the retry hooks setting to workaround the following:
     # https://github.com/canonical/temporal-k8s-operator/issues/133
     juju model-config -m temporal-test automatically-retry-hooks=true
 

--- a/modules/charmed-temporal/justfile
+++ b/modules/charmed-temporal/justfile
@@ -18,6 +18,10 @@ destroy-model:
 # Add a fresh model
 add-model: (destroy-model)
     juju add-model temporal-test
+    # Concierge's k8s preset bootstraps with automatically-retry-hooks=false; re-enable so the
+    # temporal servers self-heal the transient db-relation-changed failure on a cold deploy. See:
+    # https://github.com/canonical/temporal-k8s-operator/issues/133
+    juju model-config -m temporal-test automatically-retry-hooks=true
 
 # Appends model_uuid to variables_file (does not copy). Requires Juju model temporal-test.
 validate_test_tfvars variables_file:

--- a/modules/charmed-temporal/test/goss-services.yaml
+++ b/modules/charmed-temporal/test/goss-services.yaml
@@ -1,0 +1,37 @@
+# Goss tests asserting each temporal-k8s workload is actually running
+# as the single microservice implied by its application name, rather
+# than all services in one monolithic process. Inspects the effective
+# pebble plan inside each unit's "temporal" container.
+command:
+  temporal-frontend-service:
+    exec: "kubectl exec -n temporal-test temporal-frontend-0 -c temporal -- pebble plan"
+    exit-status: 0
+    timeout: 10000
+    stdout:
+      - "--service=frontend"
+      - "--service=internal-frontend"
+    stderr: []
+
+  temporal-history-service:
+    exec: "kubectl exec -n temporal-test temporal-history-0 -c temporal -- pebble plan"
+    exit-status: 0
+    timeout: 10000
+    stdout:
+      - "--service=history"
+    stderr: []
+
+  temporal-matching-service:
+    exec: "kubectl exec -n temporal-test temporal-matching-0 -c temporal -- pebble plan"
+    exit-status: 0
+    timeout: 10000
+    stdout:
+      - "--service=matching"
+    stderr: []
+
+  temporal-worker-service:
+    exec: "kubectl exec -n temporal-test temporal-worker-0 -c temporal -- pebble plan"
+    exit-status: 0
+    timeout: 10000
+    stdout:
+      - "--service=worker"
+    stderr: []


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

The services config option was not set to any default for the temporal-server deployments, meaning all the Temporal Servers were deployed as history, matching, frontend, worker, which is contradicting the intention of having a microservice approach. This commit sets the default to the corresponding service and prevents users from overriding this config.

Fixes #23

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

1. Deploy

```
cd modules/charmed-temporal
just add-model
just validate_test_tfvars "./test/terraform_test.tfvars"
just apply "./test/terraform_test.tfvars"
just wait-for-active
```

2. Check the config of each temporal-k8s app:

```
juju config temporal-* services  # e.g. temporal-frontend should be frontend
```

3. Check the workload actually picked it up:

```
juju ssh --container temporal temporal-matching/0 bash
ps aux

# Check the command points at just ONE ---service
```

4. (optional) Run the goss tests

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [x] Documentation updated
